### PR TITLE
Added support for a .tfswitchrc file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,65 +3,85 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:35079f2cb6f8db82741f69e2bba9bc7abaeec1137b524b5c4b29509aadf965eb"
   name = "github.com/chzyer/readline"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f6d7a1f6fbf35bbf9beb80dc63c56a29dcfb759f"
 
 [[projects]]
   branch = "master"
+  digest = "1:e51f40f0c19b39c1825eadd07d5c0a98a2ad5942b166d9fc4f54750ce9a04810"
   name = "github.com/juju/ansiterm"
   packages = [
     ".",
-    "tabwriter"
+    "tabwriter",
   ]
+  pruneopts = "UT"
   revision = "720a0952cc2ac777afc295d9861263e2a4cf96a1"
 
 [[projects]]
   branch = "master"
+  digest = "1:586d64cc78241ec7896fd170256b1d1f98bfd16757fce222927fd928431461a1"
   name = "github.com/lunixbochs/vtclean"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d14193dfc626125c831501c1c42340b4248e1f5a"
 
 [[projects]]
   branch = "master"
+  digest = "1:7f7799cc0ef4fe591dbd165e2d0920d2061e8490e0bc1ea7c797739367b4a2d5"
   name = "github.com/manifoldco/promptui"
   packages = [
     ".",
     "list",
-    "screenbuf"
+    "screenbuf",
   ]
+  pruneopts = "UT"
   revision = "c0c0d3afc6a03bcb5c1df10b70b862a650db9f9b"
 
 [[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "UT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:e26c0e7f85b846550cfe64561a3451f8cb624ba85e6d2728b21706ec3fc934fa"
   name = "github.com/pborman/getopt"
   packages = [
     ".",
-    "v2"
+    "v2",
   ]
+  pruneopts = "UT"
   revision = "7148bc3a4c3008adfcab60cbebfd0576018f330b"
 
 [[projects]]
   branch = "master"
+  digest = "1:38d86cb18bfc409c9f5667962e89395b2a01f1dfc0a1df01b5706f329e06d093"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a5dc72475471726b59af6f658f3a1e826062fdc6b42689d1943e239d936df0cb"
+  input-imports = [
+    "github.com/manifoldco/promptui",
+    "github.com/pborman/getopt",
+    "github.com/pborman/getopt/v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/warrensbox/terraform-switcher)](https://goreportcard.com/report/github.com/warrensbox/terraform-switcher)
 [![CircleCI](https://circleci.com/gh/warrensbox/terraform-switcher/tree/master.svg?style=shield&circle-token=55ddceec95ff67eb38269152282f8a7d761c79a5)](https://circleci.com/gh/warrensbox/terraform-switcher)
 
-# Terraform Switcher 
+# Terraform Switcher
 
 <img style="text-allign:center" src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/smallerlogo.png" alt="drawing" width="120" height="130"/>
 
 <!-- ![gopher](https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/logo.png =100x20) -->
 
-The `tfswitch` command line tool lets you switch between different versions of [terraform](https://www.terraform.io/). 
+The `tfswitch` command line tool lets you switch between different versions of [terraform](https://www.terraform.io/).
 If you do not have a particular version of terraform installed, `tfswitch` will download the version you desire.
-The installation is minimal and easy. 
-Once installed, simply select the version you require from the dropdown and start using terraform. 
+The installation is minimal and easy.
+Once installed, simply select the version you require from the dropdown and start using terraform.
 
 See installation guide here: [tfswitch installation](https://warrensbox.github.io/terraform-switcher/)
 
@@ -21,7 +21,7 @@ See installation guide here: [tfswitch installation](https://warrensbox.github.i
 
 ### Homebrew
 
-Installation for MacOS is the easiest with Homebrew. [If you do not have homebrew installed, click here](https://brew.sh/). 
+Installation for MacOS is the easiest with Homebrew. [If you do not have homebrew installed, click here](https://brew.sh/).
 
 
 ```ruby
@@ -38,13 +38,13 @@ curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/
 
 ### Install from source
 
-Alternatively, you can install the binary from source [here](https://github.com/warrensbox/terraform-switcher/releases) 
+Alternatively, you can install the binary from source [here](https://github.com/warrensbox/terraform-switcher/releases)
 
 ## How to use:
 ### Use dropdown menu to select version
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch.gif" alt="drawing" style="width: 180px;"/>
 
-1.  You can switch between different versions of terraform by typing the command `tfswitch` on your terminal. 
+1.  You can switch between different versions of terraform by typing the command `tfswitch` on your terminal.
 2.  Select the version of terraform you require by using the up and down arrow.
 3.  Hit **Enter** to select the desired version.
 
@@ -56,6 +56,41 @@ The most recently selected versions are presented at the top of the dropdown.
 1. You can also supply the desired version as an argument on the command line.
 2. For example, `tfswitch 0.10.5` for version 0.10.5 of terraform.
 3. Hit **Enter** to switch.
+
+### Use .tfswitchrc file
+
+1. Create a `.tfswitchrc` file containing the desired version
+2. For example, `echo "0.10.5" >> .tfswitchrc` for version 0.10.5 of terraform
+3. Run the command `tfswitch` in the same directory as your `.tfswitchrc`
+
+**Automatically switch with zsh**
+
+Add the following to the end of your `~/.zshrc` file:
+```
+load-tfswitch() {
+  local tfswitchrc_path=".tfswitchrc"
+
+  if [ -f "$tfswitchrc_path" ]; then
+    tfswitch
+  fi
+}
+add-zsh-hook chpwd load-tfswitch
+load-tfswitch
+```
+
+**Automatically switch with bash**
+
+Add the following to the end of your `~/.bashrc` file:
+```
+cdtfswitch(){
+  cd "$@";
+  if [ -f ".tfswitchrc" ]; then
+    tfswitch
+  fi
+}
+alias cd='cdtfswitch'
+
+```
 
 ## Additional Info
 

--- a/main.go
+++ b/main.go
@@ -19,8 +19,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"regexp"
 
@@ -42,6 +44,13 @@ func main() {
 
 	getopt.Parse()
 	args := getopt.Args()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Printf("Failed to get current directory %v\n", err)
+		os.Exit(1)
+	}
+	rcfile := dir + "/.tfswitchrc"
 
 	if *versionFlag {
 		fmt.Printf("\nVersion: %v\n", version)
@@ -71,6 +80,17 @@ func main() {
 				usageMessage()
 			}
 
+		} else if _, err := os.Stat(rcfile); err == nil {
+
+			file_contents, err := ioutil.ReadFile(rcfile)
+			if err != nil {
+				log.Printf("Failed to read .tfswitchrc %v\n", err)
+				os.Exit(1)
+			}
+			tfversion := strings.TrimSuffix(string(file_contents), "\n")
+
+			lib.AddRecent(string(tfversion)) //add to recent file for faster lookup
+			lib.Install(string(tfversion))
 		} else if len(args) == 0 {
 
 			tflist, _ := lib.GetTFList(hashiURL)


### PR DESCRIPTION
Added the ability to include a `.tfswitchrc` file within a repo to have tfswitch automatically use the desired Terraform version. 

Similar idea to [nvm](https://github.com/creationix/nvm).