### PR TITLE
document fix for 'command not found: add-zsh-hook'

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ load-tfswitch() {
 add-zsh-hook chpwd load-tfswitch
 load-tfswitch
 ```
+> NOTE: if you see an error like this: `command not found: add-zsh-hook`, then you might be on an older version of zsh (see below), or you simply need to load `add-zsh-hook` by adding this to your `.zshrc`:
+>    ```
+>    autoload -U add-zsh-hook
+>    ```
 
 *older version of zsh*
 ```
@@ -122,10 +126,3 @@ See how to *upgrade*, *uninstall*, *troubleshoot* here:[More info](https://warre
 ## Issues
 
 Please open  *issues* here: [New Issue](https://github.com/warrensbox/terraform-switcher/issues)
-
-
-
-
-
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,10 @@ load-tfswitch() {
 add-zsh-hook chpwd load-tfswitch
 load-tfswitch
 ```
+> NOTE: if you see an error like this: `command not found: add-zsh-hook`, then you might be on an older version of zsh (see below), or you simply need to load `add-zsh-hook` by adding this to your `.zshrc`:
+>    ```
+>    autoload -U add-zsh-hook
+>    ```
 
 *older version of zsh*
 ```


### PR DESCRIPTION
I hit the `command not found: add-zsh-hook` error when using `tfswitch` in zsh (v5.6.2).  Searched the web for a bit and realized I needed to load the `add-zsh-hook` function.