### PR TITLE
Allow expansion of environment variables in the configuration file

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 
 			bin := viper.Get("bin")                  // read custom binary location
 			if binPath == defaultBin && bin != nil { // if the bin path is the same as the default binary path and if the custom binary is provided in the toml file (use it)
-				binPath = bin.(string)
+				binPath = os.ExpandEnv(bin.(string))
 			}
 			version := viper.Get("version") //attempt to get the version if it's provided in the toml
 


### PR DESCRIPTION
I'm reluctant to change permissions on the default /usr/local/bin directory to allow tfswitch to work. This means I need to use a custom bin directory. I specified that in my config file using the $HOME environment variable:

```
:~% cat ~/.tfswitch.toml
bin = "$HOME/bin/terraform"
```
but found that tfswitch doesn't expand environment variables. This isn't an issue if I supply it as a command line argument, because the shell expands it. 

This change expands the value found in the config, using the variables defined in current environment, when it's assigned. 