### PR TITLE
Develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,8 @@ test: $(EXE)
 .PHONEY: dep
 dep:
 	dep ensure
+
+.PHONY: docs
+docs:
+	cd docs; bundle install --path vendor/bundler; bundle exec jekyll build -c _config.yml; cd ..
+

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ version = "0.11.3"
 2. For example, `echo "0.10.5" >> .tfswitchrc` for version 0.10.5 of terraform
 3. Run the command `tfswitch` in the same directory as your `.tfswitchrc`
 
-*instead of a `.tfswitchrc` file, a `.terraform-version` file may be used for compatibility with [`tfenv`](https://github.com/tfutils/tfenv#terraform-version-file) and other tools which use it*
+*Instead of a `.tfswitchrc` file, a `.terraform-version` file may be used for compatibility with [`tfenv`](https://github.com/tfutils/tfenv#terraform-version-file) and other tools which use it*
 
 **Automatically switch with bash**
 
 Add the following to the end of your `~/.bashrc` file:
-(Use either `.tfswitchrc` or `.tfswitch.toml`)
+(Use either `.tfswitchrc` or `.tfswitch.toml` or `.terraform-version`)
 
 ```
 cdtfswitch(){
@@ -136,6 +136,18 @@ cd(){
     tfswitch
   fi
 }
+```
+
+### Jenkins setup
+```
+#!/bin/bash 
+
+echo "Installing tfswitch locally"
+wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh 
+chmod 755 install.sh
+./install.sh -b bin-directory
+
+./bin-directory/tfswitch
 ```
 
 ## Additional Info

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The most recently selected versions are presented at the top of the dropdown.
 ### Use .tfswitch.toml file  (For non-admin - users with limited privilege on their computers)
 This is similiar to using a .tfswitchrc file, but you can specify a custom binary path for your terraform installation
 
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 170px;"/>   
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v8.gif" alt="drawing" style="width: 170px;"/>
 
 1. Create a custom binary path. Ex: `mkdir /Users/warrenveerasingam/bin` (replace warrenveerasingam with your username)
@@ -80,9 +81,6 @@ bin = "/Users/warrenveerasingam/bin/terraform"
 version = "0.11.3"
 ```
 4. Run `tfswitch` and it should automatically install the required terraform version in the specified binary path
-
-<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 170px;"/>
-
 
 ### Use .tfswitchrc file
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v6.gif" alt="drawing" style="width: 170px;"/>

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ cd(){
 ```
 
 ### Jenkins setup
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/jenkins_tfswitch.png" alt="drawing" style="width: 170px;"/>
+
 ```
 #!/bin/bash 
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,6 +26,9 @@
 
       gtag('config', 'UA-120055973-1');
     </script>
+
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </head>
   <body>
     <div class="wrapper">
@@ -51,17 +54,20 @@
           <li><a href="https://github.com/warrensbox/terraform-switcher/releases">Releases On <strong>GitHub</strong></a></li>
         </ul>
         {% endif %}
+
+        <!-- Place this tag where you want the button to render. -->
+<a class="github-button" href="https://github.com/warrensbox/terraform-switcher" data-size="large" data-show-count="true" aria-label="Star warrensbox/terraform-switcher on GitHub">Star</a>
       </header>
       <section>
 
       {{ content }}
       {% if site.github.is_project_page %}
-      <p><small>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></small></p>
+      <p><small>This project is maintained by <a href="{{ site.github.repository_url }}">{{ site.github.owner_name }}</a></small></p>
       {% endif %}
       </section>
       <footer>
         <!-- <p><small>View other products &mdash; by <a href="http://warren.veerasingam.com/#about_me" target="_blank">Warren Veerasingam</a></small></p> -->
-        <p><small>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></small></p>
+        <p><small>This project is maintained by <a href="{{ site.github.repository_url }}">{{ site.github.owner_name }}</a></small></p>
       </footer>
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>

--- a/docs/_site/additional.html
+++ b/docs/_site/additional.html
@@ -23,7 +23,7 @@
 {"description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebPage","url":"/additional.html","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"tfswitch","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=45af5d166a97ba6db56ba31181768391887b4abd">
+    <link rel="stylesheet" href="/assets/css/style.css?v=f466e1f1c1220520b876a4984c343b52a5f06826">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->

--- a/docs/_site/additional.html
+++ b/docs/_site/additional.html
@@ -23,7 +23,7 @@
 {"description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebPage","url":"/additional.html","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"tfswitch","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=f466e1f1c1220520b876a4984c343b52a5f06826">
+    <link rel="stylesheet" href="/assets/css/style.css?v=0b7be9932efc2fc12b75f7de015e535bb13fda26">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->

--- a/docs/_site/additional.html
+++ b/docs/_site/additional.html
@@ -23,7 +23,7 @@
 {"description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebPage","url":"/additional.html","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"tfswitch","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=bc81752d81190c607469fb32bfc1b6836b729696">
+    <link rel="stylesheet" href="/assets/css/style.css?v=45af5d166a97ba6db56ba31181768391887b4abd">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -37,6 +37,9 @@
 
       gtag('config', 'UA-120055973-1');
     </script>
+
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </head>
   <body>
     <div class="wrapper">
@@ -62,6 +65,9 @@
           <li><a href="https://github.com/warrensbox/terraform-switcher/releases">Releases On <strong>GitHub</strong></a></li>
         </ul>
         
+
+        <!-- Place this tag where you want the button to render. -->
+<a class="github-button" href="https://github.com/warrensbox/terraform-switcher" data-size="large" data-show-count="true" aria-label="Star warrensbox/terraform-switcher on GitHub">Star</a>
       </header>
       <section>
 
@@ -111,12 +117,12 @@
 <a href="index">Back to main</a></p>
 
       
-      <p><small>This project is maintained by <a href="http://github.com/warrensbox">warrensbox</a></small></p>
+      <p><small>This project is maintained by <a href="http://github.com/warrensbox/terraform-switcher">warrensbox</a></small></p>
       
       </section>
       <footer>
         <!-- <p><small>View other products &mdash; by <a href="http://warren.veerasingam.com/#about_me" target="_blank">Warren Veerasingam</a></small></p> -->
-        <p><small>This project is maintained by <a href="http://github.com/warrensbox">warrensbox</a></small></p>
+        <p><small>This project is maintained by <a href="http://github.com/warrensbox/terraform-switcher">warrensbox</a></small></p>
       </footer>
     </div>
     <script src="/assets/js/scale.fix.js"></script>

--- a/docs/_site/additional.html
+++ b/docs/_site/additional.html
@@ -23,7 +23,7 @@
 {"description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebPage","url":"/additional.html","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"tfswitch","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=d03b39eb1bc647c22c941fe3cde1de0c34ccf038">
+    <link rel="stylesheet" href="/assets/css/style.css?v=bc81752d81190c607469fb32bfc1b6836b729696">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->

--- a/docs/_site/additional.html
+++ b/docs/_site/additional.html
@@ -23,7 +23,7 @@
 {"description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebPage","url":"/additional.html","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"tfswitch","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=b5d2e9c5061f970064e2d889ea88fc4d54079084">
+    <link rel="stylesheet" href="/assets/css/style.css?v=d03b39eb1bc647c22c941fe3cde1de0c34ccf038">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -57,8 +57,8 @@
 
         
         <ul>
-          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.0/terraform-switcher_0.7.0_darwin_amd64.tar.gz">Download <strong>MacOS</strong></a></li>
-          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.0/terraform-switcher_0.7.0_linux_amd64.tar.gz">Download <strong>Linux</strong></a></li>
+          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.737/terraform-switcher_0.7.737_darwin_amd64.tar.gz">Download <strong>MacOS</strong></a></li>
+          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.737/terraform-switcher_0.7.737_linux_amd64.tar.gz">Download <strong>Linux</strong></a></li>
           <li><a href="https://github.com/warrensbox/terraform-switcher/releases">Releases On <strong>GitHub</strong></a></li>
         </ul>
         

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -23,7 +23,7 @@
 {"name":"tfswitch","description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebSite","url":"/","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"Terraform Switcher","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=f466e1f1c1220520b876a4984c343b52a5f06826">
+    <link rel="stylesheet" href="/assets/css/style.css?v=0b7be9932efc2fc12b75f7de015e535bb13fda26">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -210,6 +210,8 @@ load-tfswitch
 </code></pre></div></div>
 
 <h3 id="jenkins-setup">Jenkins setup</h3>
+<p><img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/jenkins_tfswitch.png" alt="drawing" style="width: 170px;" /></p>
+
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="c">#!/bin/bash </span>
 
 <span class="nb">echo</span> <span class="s2">"Installing tfswitch locally"</span>

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -23,7 +23,7 @@
 {"name":"tfswitch","description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebSite","url":"/","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"Terraform Switcher","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=b5d2e9c5061f970064e2d889ea88fc4d54079084">
+    <link rel="stylesheet" href="/assets/css/style.css?v=d03b39eb1bc647c22c941fe3cde1de0c34ccf038">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -57,8 +57,8 @@
 
         
         <ul>
-          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.0/terraform-switcher_0.7.0_darwin_amd64.tar.gz">Download <strong>MacOS</strong></a></li>
-          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.0/terraform-switcher_0.7.0_linux_amd64.tar.gz">Download <strong>Linux</strong></a></li>
+          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.737/terraform-switcher_0.7.737_darwin_amd64.tar.gz">Download <strong>MacOS</strong></a></li>
+          <li><a href="https://github.com/warrensbox/terraform-switcher/releases/download/0.7.737/terraform-switcher_0.7.737_linux_amd64.tar.gz">Download <strong>Linux</strong></a></li>
           <li><a href="https://github.com/warrensbox/terraform-switcher/releases">Releases On <strong>GitHub</strong></a></li>
         </ul>
         
@@ -131,7 +131,8 @@ Once installed, simply select the version you require from the dropdown and star
 <h3 id="use-tfswitchtoml-file--for-non-admin---users-with-limited-privilege-on-their-computers">Use .tfswitch.toml file  (For non-admin - users with limited privilege on their computers)</h3>
 <p>This is similiar to using a .tfswitchrc file, but you can specify a custom binary path for your terraform installation</p>
 
-<p><img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v8.gif" alt="drawing" style="width: 490px;" /></p>
+<p><img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 490px;" />
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v8.gif" alt="drawing" style="width: 490px;" /></p>
 
 <ol>
   <li>Create a custom binary path. Ex: <code class="highlighter-rouge">mkdir /Users/warrenveerasingam/bin</code> (replace warrenveerasingam with your username)</li>
@@ -145,8 +146,6 @@ version = "0.11.3"
   </li>
   <li>Run <code class="highlighter-rouge">tfswitch</code> and it should automatically install the required terraform version in the specified binary path</li>
 </ol>
-
-<p><img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 490px;" /></p>
 
 <h3 id="use-tfswitchrc-file">Use .tfswitchrc file</h3>
 <p><img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v6.gif" alt="drawing" style="width: 490px;" /></p>

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -23,7 +23,7 @@
 {"name":"tfswitch","description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebSite","url":"/","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"Terraform Switcher","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=bc81752d81190c607469fb32bfc1b6836b729696">
+    <link rel="stylesheet" href="/assets/css/style.css?v=45af5d166a97ba6db56ba31181768391887b4abd">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -37,6 +37,9 @@
 
       gtag('config', 'UA-120055973-1');
     </script>
+
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </head>
   <body>
     <div class="wrapper">
@@ -62,6 +65,9 @@
           <li><a href="https://github.com/warrensbox/terraform-switcher/releases">Releases On <strong>GitHub</strong></a></li>
         </ul>
         
+
+        <!-- Place this tag where you want the button to render. -->
+<a class="github-button" href="https://github.com/warrensbox/terraform-switcher" data-size="large" data-show-count="true" aria-label="Star warrensbox/terraform-switcher on GitHub">Star</a>
       </header>
       <section>
 
@@ -213,12 +219,12 @@ load-tfswitch
 <a href="additional">Additional Info</a></p>
 
       
-      <p><small>This project is maintained by <a href="http://github.com/warrensbox">warrensbox</a></small></p>
+      <p><small>This project is maintained by <a href="http://github.com/warrensbox/terraform-switcher">warrensbox</a></small></p>
       
       </section>
       <footer>
         <!-- <p><small>View other products &mdash; by <a href="http://warren.veerasingam.com/#about_me" target="_blank">Warren Veerasingam</a></small></p> -->
-        <p><small>This project is maintained by <a href="http://github.com/warrensbox">warrensbox</a></small></p>
+        <p><small>This project is maintained by <a href="http://github.com/warrensbox/terraform-switcher">warrensbox</a></small></p>
       </footer>
     </div>
     <script src="/assets/js/scale.fix.js"></script>

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -23,7 +23,7 @@
 {"name":"tfswitch","description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebSite","url":"/","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"Terraform Switcher","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=45af5d166a97ba6db56ba31181768391887b4abd">
+    <link rel="stylesheet" href="/assets/css/style.css?v=f466e1f1c1220520b876a4984c343b52a5f06826">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
@@ -162,10 +162,12 @@ version = "0.11.3"
   <li>Run the command <code class="highlighter-rouge">tfswitch</code> in the same directory as your <code class="highlighter-rouge">.tfswitchrc</code>.</li>
 </ol>
 
+<p><em>Instead of a <code class="highlighter-rouge">.tfswitchrc</code> file, a <code class="highlighter-rouge">.terraform-version</code> file may be used for compatibility with <a href="https://github.com/tfutils/tfenv#terraform-version-file"><code class="highlighter-rouge">tfenv</code></a> and other tools which use it</em></p>
+
 <p><strong>Automatically switch with bash</strong></p>
 
 <p>Add the following to the end of your <code class="highlighter-rouge">~/.bashrc</code> file: 
-(Use either <code class="highlighter-rouge">.tfswitchrc</code> or <code class="highlighter-rouge">.tfswitch.toml</code>)</p>
+(Use either <code class="highlighter-rouge">.tfswitchrc</code> or <code class="highlighter-rouge">.tfswitch.toml</code> or <code class="highlighter-rouge">.terraform-version</code>)</p>
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>cdtfswitch(){
   builtin cd "$@";
@@ -205,6 +207,17 @@ load-tfswitch
     tfswitch
   fi
 }
+</code></pre></div></div>
+
+<h3 id="jenkins-setup">Jenkins setup</h3>
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="c">#!/bin/bash </span>
+
+<span class="nb">echo</span> <span class="s2">"Installing tfswitch locally"</span>
+wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh 
+chmod 755 install.sh
+./install.sh <span class="nt">-b</span> bin-directory
+
+./bin-directory/tfswitch
 </code></pre></div></div>
 
 <hr />

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -23,7 +23,7 @@
 {"name":"tfswitch","description":"Manage terraform versions - the tfswitch command line tool lets you switch between different versions of terraform","@type":"WebSite","url":"/","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"/assets/img/logo.png"}},"headline":"Terraform Switcher","@context":"http://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="/assets/css/style.css?v=d03b39eb1bc647c22c941fe3cde1de0c34ccf038">
+    <link rel="stylesheet" href="/assets/css/style.css?v=bc81752d81190c607469fb32bfc1b6836b729696">
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->

--- a/docs/_site/index.md
+++ b/docs/_site/index.md
@@ -61,6 +61,7 @@ The most recently selected versions are presented at the top of the dropdown.
 ### Use .tfswitch.toml file  (For non-admin - users with limited privilege on their computers)
 This is similiar to using a .tfswitchrc file, but you can specify a custom binary path for your terraform installation
 
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 490px;"/>
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v8.gif" alt="drawing" style="width: 490px;"/>
 
 1. Create a custom binary path. Ex: `mkdir /Users/warrenveerasingam/bin` (replace warrenveerasingam with your username)
@@ -73,8 +74,6 @@ bin = "/Users/warrenveerasingam/bin/terraform"
 version = "0.11.3"
 ```
 4. Run `tfswitch` and it should automatically install the required terraform version in the specified binary path
-
-<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 490px;"/>
 
 ### Use .tfswitchrc file
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v6.gif" alt="drawing" style="width: 490px;"/>

--- a/docs/_site/index.md
+++ b/docs/_site/index.md
@@ -132,6 +132,8 @@ cd(){
 ```
 
 ### Jenkins setup
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/jenkins_tfswitch.png" alt="drawing" style="width: 170px;"/>
+
 ```
 #!/bin/bash 
 

--- a/docs/_site/index.md
+++ b/docs/_site/index.md
@@ -82,11 +82,12 @@ version = "0.11.3"
 2. For example, `echo "0.10.5" >> .tfswitchrc` for version 0.10.5 of terraform.
 3. Run the command `tfswitch` in the same directory as your `.tfswitchrc`.
 
+*Instead of a `.tfswitchrc` file, a `.terraform-version` file may be used for compatibility with [`tfenv`](https://github.com/tfutils/tfenv#terraform-version-file) and other tools which use it*
 
 **Automatically switch with bash**
 
 Add the following to the end of your `~/.bashrc` file: 
-(Use either `.tfswitchrc` or `.tfswitch.toml`)
+(Use either `.tfswitchrc` or `.tfswitch.toml` or `.terraform-version`)
 
 ```
 cdtfswitch(){
@@ -128,6 +129,18 @@ cd(){
     tfswitch
   fi
 }
+```
+
+### Jenkins setup
+```
+#!/bin/bash 
+
+echo "Installing tfswitch locally"
+wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh 
+chmod 755 install.sh
+./install.sh -b bin-directory
+
+./bin-directory/tfswitch
 ```
 
 <hr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ The most recently selected versions are presented at the top of the dropdown.
 ### Use .tfswitch.toml file  (For non-admin - users with limited privilege on their computers)
 This is similiar to using a .tfswitchrc file, but you can specify a custom binary path for your terraform installation
 
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 490px;"/>
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v8.gif" alt="drawing" style="width: 490px;"/>
 
 1. Create a custom binary path. Ex: `mkdir /Users/warrenveerasingam/bin` (replace warrenveerasingam with your username)
@@ -73,8 +74,6 @@ bin = "/Users/warrenveerasingam/bin/terraform"
 version = "0.11.3"
 ```
 4. Run `tfswitch` and it should automatically install the required terraform version in the specified binary path
-
-<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v7.gif" alt="drawing" style="width: 490px;"/>
 
 ### Use .tfswitchrc file
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v6.gif" alt="drawing" style="width: 490px;"/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,6 +132,8 @@ cd(){
 ```
 
 ### Jenkins setup
+<img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/jenkins_tfswitch.png" alt="drawing" style="width: 170px;"/>
+
 ```
 #!/bin/bash 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,11 +82,12 @@ version = "0.11.3"
 2. For example, `echo "0.10.5" >> .tfswitchrc` for version 0.10.5 of terraform.
 3. Run the command `tfswitch` in the same directory as your `.tfswitchrc`.
 
+*Instead of a `.tfswitchrc` file, a `.terraform-version` file may be used for compatibility with [`tfenv`](https://github.com/tfutils/tfenv#terraform-version-file) and other tools which use it*
 
 **Automatically switch with bash**
 
 Add the following to the end of your `~/.bashrc` file: 
-(Use either `.tfswitchrc` or `.tfswitch.toml`)
+(Use either `.tfswitchrc` or `.tfswitch.toml` or `.terraform-version`)
 
 ```
 cdtfswitch(){
@@ -128,6 +129,18 @@ cd(){
     tfswitch
   fi
 }
+```
+
+### Jenkins setup
+```
+#!/bin/bash 
+
+echo "Installing tfswitch locally"
+wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh 
+chmod 755 install.sh
+./install.sh -b bin-directory
+
+./bin-directory/tfswitch
 ```
 
 <hr>

--- a/lib/install.go
+++ b/lib/install.go
@@ -22,7 +22,7 @@ var (
 	//installedBinPath = "/tmp"
 )
 
-func init() {
+func initialize() {
 	/* get current user */
 	usr, errCurr := user.Current()
 	if errCurr != nil {
@@ -64,6 +64,17 @@ func Install(tfversion string, binPath string) {
 		fmt.Printf("The provided terraform version format does not exist - %s. Try `tfswitch -l` to see all available versions.\n", tfversion)
 		os.Exit(1)
 	}
+
+	pathDir := Path(binPath)              //get path directory from binary path
+	binDirExist := CheckDirExist(pathDir) //check bin path exist
+
+	if !binDirExist {
+		fmt.Printf("Error - Binary path does not exist: %s\n", pathDir)
+		fmt.Printf("Create binary path: %s for terraform installation\n", pathDir)
+		os.Exit(1)
+	}
+
+	initialize() //initialize path
 
 	goarch := runtime.GOARCH
 	goos := runtime.GOOS
@@ -113,6 +124,7 @@ func Install(tfversion string, binPath string) {
 	/* remove zipped file to clear clutter */
 	RemoveFiles(installLocation + installVersion + tfversion + "_" + goos + "_" + goarch + ".zip")
 
+	fmt.Println("rm2 symlink")
 	/* remove current symlink if exist*/
 	symlinkExist := CheckSymlink(binPath)
 

--- a/lib/install.go
+++ b/lib/install.go
@@ -188,7 +188,6 @@ func AddRecent(requestedVersion string) {
 		}
 
 	} else {
-		fmt.Println("adding to recent5")
 		CreateRecentFile(requestedVersion)
 	}
 }

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"fmt"
 	"log"
 	"os"
 )
@@ -23,7 +24,7 @@ func CreateSymlink(cwd string, dir string) {
 
 //RemoveSymlink : remove symlink
 func RemoveSymlink(symlinkPath string) {
-
+	fmt.Println(symlinkPath)
 	_, err := os.Lstat(symlinkPath)
 	if err != nil {
 		log.Fatalf(`
@@ -36,6 +37,7 @@ func RemoveSymlink(symlinkPath string) {
 		os.Exit(1)
 	} else {
 		errRemove := os.Remove(symlinkPath)
+		fmt.Println("ATTEMPING TO RM")
 		if errRemove != nil {
 			log.Fatalf(`
 			Unable to remove symlink.

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"fmt"
 	"log"
 	"os"
 )
@@ -24,7 +23,7 @@ func CreateSymlink(cwd string, dir string) {
 
 //RemoveSymlink : remove symlink
 func RemoveSymlink(symlinkPath string) {
-	fmt.Println(symlinkPath)
+
 	_, err := os.Lstat(symlinkPath)
 	if err != nil {
 		log.Fatalf(`
@@ -37,7 +36,7 @@ func RemoveSymlink(symlinkPath string) {
 		os.Exit(1)
 	} else {
 		errRemove := os.Remove(symlinkPath)
-		fmt.Println("ATTEMPING TO RM")
+
 		if errRemove != nil {
 			log.Fatalf(`
 			Unable to remove symlink.

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func main() {
 			}
 
 		} else if _, err := os.Stat(rcfile); err == nil && len(args) == 0 { //if there is a .tfswitchrc file, and no commmand line arguments
-			fmt.Printf("Reading required terraform version %s ", rcFilename)
+			fmt.Printf("Reading required terraform version %s \n", rcFilename)
 
 			fileContents, err := ioutil.ReadFile(rcfile)
 			if err != nil {
@@ -140,7 +140,7 @@ func main() {
 				os.Exit(1)
 			}
 		} else if _, err := os.Stat(tfvfile); err == nil && len(args) == 0 { //if there is a .terraform-version file, and no command line arguments
-			fmt.Printf("Reading required terraform version %s ", tfvFilename)
+			fmt.Printf("Reading required terraform version %s \n", tfvFilename)
 
 			fileContents, err := ioutil.ReadFile(tfvfile)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -105,14 +105,7 @@ func main() {
 				tfversion = version.(string)
 			}
 
-			pathDir := lib.Path(binPath)              //get path directory from binary path
-			binDirExist := lib.CheckDirExist(pathDir) //check bin path exist
-
-			if !binDirExist {
-				fmt.Printf("Binary path does not exist: %s\n", pathDir)
-				fmt.Printf("Create binary path: %s for terraform installation\n", pathDir)
-				os.Exit(1)
-			} else if *listAllFlag { //show all terraform version including betas and RCs
+			if *listAllFlag { //show all terraform version including betas and RCs
 				listAll := true //set list all true - all versions including beta and rc will be displayed
 				installOption(listAll, &binPath)
 			} else if tfversion == "" { // if no version is provided, show a dropdown of available release versions


### PR DESCRIPTION
1. Prevent bug that removes symlink. This should fix the issue where `ctrl+c` or `tfswitch -h` removes the symlink.

1. Add error message if  custom `"bin"` directory is not created before using `-b`,`--bin` or `.tfswitch.toml` with bin option
