### PR TITLE
unzip to non-root dir when sudo'd

### DIFF
--- a/lib/download.go
+++ b/lib/download.go
@@ -12,7 +12,7 @@ import (
 func DownloadFromURL(installLocation string, url string) (string, error) {
 	tokens := strings.Split(url, "/")
 	fileName := tokens[len(tokens)-1]
-	fmt.Println("Downloading", url, "to", fileName)
+	fmt.Printf("Downloading %s to %s%s\n", url, installLocation, fileName)
 	fmt.Println("Downloading ...")
 
 	response, err := http.Get(url)

--- a/lib/install.go
+++ b/lib/install.go
@@ -60,6 +60,11 @@ func getInstallLocation() string {
 
 	/* set installation location */
 	installLocation = usr.HomeDir + installPath
+	if usr.Uid == "0" {
+		// if we're root, use /usr/local/terraform
+		installLocation = "/usr/local/terraform/"
+		fmt.Printf("Running as root, installing to %s\n", installLocation)
+	}
 
 	/* Create local installation directory if it does not exist */
 	CreateDirIfNotExist(installLocation)


### PR DESCRIPTION
for example, downloading and unzipping to `/usr/local/terraform` is safer when sudo'd - otherwise, the `/usr/local/bin/terraform` points to something that only root can run


for #133