### PR TITLE
♿  changes to make tfswitch work on windows, fix some test 🐛 bugs, ♻️ refactor code, add 🚀 ci on `windows/osx`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: go
 install: true
 
-os: 
-  - linux
-  - osx
-  - windows
-
 go:
   - "1.16"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,52 @@ install: true
 go:
   - "1.16"
 
+before_install:
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+        choco uninstall -y mingw
+        choco upgrade --no-progress -y msys2
+        export msys2='cmd //C RefreshEnv.cmd '
+        export msys2+='& set MSYS=winsymlinks:nativestrict '
+        export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+        export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+        export msys2+=" -msys2 -c "\"\$@"\" --"
+        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
+        ## Install more MSYS2 packages from https://packages.msys2.org/base here
+        taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+        export PATH=/C/tools/msys64/mingw64/bin:$PATH
+        export MAKE=mingw32-make  # so that Autotools can find it
+        ;;
+    esac
+
+before_cache:
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        # https://unix.stackexchange.com/a/137322/107554
+        $msys2 pacman --sync --clean --noconfirm
+        ;;
+    esac
+
+cache:
+    directories:
+    - $HOME/AppData/Local/Temp/chocolatey
+    - /C/tools/msys64
+
 jobs:
   include:
-    - os:
-        - linux
-        - osx
+    - os: linux
+      script:
+        - make test
+        - make clean
+    - os: osx
       script:
         - make test
         - make clean
     - os: windows
       script:
         - echo $SHELL
+        - make test
+        - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,35 +4,6 @@ install: true
 go:
   - "1.16"
 
-before_install:
-- |-
-    case $TRAVIS_OS_NAME in
-      windows)
-        [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
-        choco uninstall -y mingw
-        choco upgrade --no-progress -y msys2
-        export msys2='cmd //C RefreshEnv.cmd '
-        export msys2+='& set MSYS=winsymlinks:nativestrict '
-        export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
-        export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
-        export msys2+=" -msys2 -c "\"\$@"\" --"
-        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
-        ## Install more MSYS2 packages from https://packages.msys2.org/base here
-        taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
-        export PATH=/C/tools/msys64/mingw64/bin:$PATH
-        export MAKE=mingw32-make  # so that Autotools can find it
-        ;;
-    esac
-
-before_cache:
-- |-
-    case $TRAVIS_OS_NAME in
-      windows)
-        # https://unix.stackexchange.com/a/137322/107554
-        $msys2 pacman --sync --clean --noconfirm
-        ;;
-    esac
-
 cache:
     directories:
     - $HOME/AppData/Local/Temp/chocolatey
@@ -49,6 +20,33 @@ jobs:
         - make test
         - make clean
     - os: windows
+      before_install:
+        - |-
+            case $TRAVIS_OS_NAME in
+              windows)
+                [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+                choco uninstall -y mingw
+                choco upgrade --no-progress -y msys2
+                export msys2='cmd //C RefreshEnv.cmd '
+                export msys2+='& set MSYS=winsymlinks:nativestrict '
+                export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+                export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+                export msys2+=" -msys2 -c "\"\$@"\" --"
+                $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
+                ## Install more MSYS2 packages from https://packages.msys2.org/base here
+                taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+                export PATH=/C/tools/msys64/mingw64/bin:$PATH
+                export MAKE=mingw32-make  # so that Autotools can find it
+                ;;
+            esac
+      before_cache:
+        - |-
+            case $TRAVIS_OS_NAME in
+              windows)
+                # https://unix.stackexchange.com/a/137322/107554
+                $msys2 pacman --sync --clean --noconfirm
+                ;;
+            esac
       script:
         - echo $SHELL
         - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,15 @@ os:
 go:
   - "1.16"
 
-addons:
-  choco:
-    - make
+jobs:
+  include:
+    - os:
+        - linux
+        - osx
+      script:
+      - make test
+      - make clean
+    - os: windows
+      script:
+        - echo $SHELL
 
-script:
-  - make test
-  - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: go
 install: true
 
+os: 
+  - linux
+  - osx
+  - windows
+
 go:
   - "1.16"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ os:
 go:
   - "1.16"
 
+addons:
+  choco:
+    - make
+
 script:
   - make test
   - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ jobs:
         - linux
         - osx
       script:
-      - make test
-      - make clean
+        - make test
+        - make clean
     - os: windows
       script:
         - echo $SHELL
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 
 cache:
     directories:
+    - $HOME/go
     - $HOME/AppData/Local/Temp/chocolatey
     - /C/tools/msys64
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,5 @@ jobs:
                 ;;
             esac
       script:
-        - echo $SHELL
-        - make test
-        - make clean
+        - $MAKE test
+        - $MAKE clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,28 @@ install: true
 go:
   - "1.16"
 
-cache:
-    directories:
-    - $HOME/go
-    - $HOME/AppData/Local/Temp/chocolatey
-    - /C/tools/msys64
-
 jobs:
   include:
     - os: linux
+      cache:
+        directories:
+          - $HOME/go
       script:
         - make test
         - make clean
     - os: osx
+      cache:
+        directories:
+          - $HOME/go
       script:
         - make test
         - make clean
     - os: windows
+      cache:
+        directories:
+          - $HOME/go
+          - $HOME/AppData/Local/Temp/chocolatey
+          - /C/tools/msys64
       before_install:
         - |-
             case $TRAVIS_OS_NAME in

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ The most recently selected versions are presented at the top of the dropdown.
 2. For example, `tfswitch 0.10.5` for version 0.10.5 of terraform.
 3. Hit **Enter** to switch.
 
+**NOTE** for windows host `tfswitch` need to be run under `Administrator` mode, and `$HOME/.tfswitch.toml` with `bin` must be defined to an valid path as minimum, below is an example for `$HOME/.tfswitch.toml` on windows
+
+```toml
+bin = "C:\\Users\\<%USRNAME%>\\bin\\terraform.exe"
+```
+
 ### See all versions including beta, alpha and release candidates(rc)
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/tfswitch-v5.gif#1" alt="drawing" style="width: 370px;"/>
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The most recently selected versions are presented at the top of the dropdown.
 2. For example, `tfswitch 0.10.5` for version 0.10.5 of terraform.
 3. Hit **Enter** to switch.
 
-**NOTE** for windows host `tfswitch` need to be run under `Administrator` mode, and `$HOME/.tfswitch.toml` with `bin` must be defined to an valid path as minimum, below is an example for `$HOME/.tfswitch.toml` on windows
+**NOTE** for windows host `tfswitch` need to be run under `Administrator` mode, and `$HOME/.tfswitch.toml` with `bin` must be defined (with a valid path) as minimum, below is an example for `$HOME/.tfswitch.toml` on windows
 
 ```toml
 bin = "C:\\Users\\<%USRNAME%>\\bin\\terraform.exe"

--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -51,7 +51,6 @@ func cleanUp(path string) {
 func removeFiles(src string) {
 	files, err := filepath.Glob(src)
 	if err != nil {
-
 		panic(err)
 	}
 	for _, f := range files {

--- a/lib/download.go
+++ b/lib/download.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -29,9 +30,10 @@ func DownloadFromURL(installLocation string, url string) (string, error) {
 		return "", fmt.Errorf("Unable to download from %s\nPlease download manually from https://releases.hashicorp.com/terraform/", url)
 	}
 
-	output, err := os.Create(installLocation + fileName)
+	zipFile := filepath.Join(installLocation, fileName)
+	output, err := os.Create(zipFile)
 	if err != nil {
-		fmt.Println("Error while creating", installLocation+fileName, "-", err)
+		fmt.Println("Error while creating", zipFile, "-", err)
 		return "", err
 	}
 	defer output.Close()
@@ -43,5 +45,5 @@ func DownloadFromURL(installLocation string, url string) (string, error) {
 	}
 
 	fmt.Println(n, "bytes downloaded.")
-	return installLocation + fileName, nil
+	return zipFile, nil
 }

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path/filepath"
 	"testing"
 
 	lib "github.com/warrensbox/terraform-switcher/lib"
@@ -26,7 +27,7 @@ func TestDownloadFromURL_FileNameMatch(t *testing.T) {
 	}
 
 	fmt.Printf("Current user: %v \n", usr.HomeDir)
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	// create /.terraform.versions_test/ directory to store code
 	if _, err := os.Stat(installLocation); os.IsNotExist(err) {
@@ -42,7 +43,7 @@ func TestDownloadFromURL_FileNameMatch(t *testing.T) {
 	lowestVersion := "0.1.0"
 
 	url := hashiURL + lowestVersion + "/" + installVersion + lowestVersion + macOS
-	expectedFile := usr.HomeDir + installPath + installVersion + lowestVersion + macOS
+	expectedFile := filepath.Join(usr.HomeDir, installPath, installVersion+lowestVersion+macOS)
 	installedFile, errDownload := lib.DownloadFromURL(installLocation, url)
 
 	if errDownload != nil {
@@ -64,7 +65,7 @@ func TestDownloadFromURL_FileNameMatch(t *testing.T) {
 	latestVersion := "0.11.7"
 
 	url = hashiURL + latestVersion + "/" + installVersion + latestVersion + macOS
-	expectedFile = usr.HomeDir + installPath + installVersion + latestVersion + macOS
+	expectedFile = filepath.Join(usr.HomeDir, installPath, installVersion+latestVersion+macOS)
 	installedFile, errDownload = lib.DownloadFromURL(installLocation, url)
 
 	if errDownload != nil {
@@ -101,7 +102,7 @@ func TestDownloadFromURL_FileExist(t *testing.T) {
 	}
 
 	fmt.Printf("Current user: %v \n", usr.HomeDir)
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	// create /.terraform.versions_test/ directory to store code
 	if _, err := os.Stat(installLocation); os.IsNotExist(err) {
@@ -117,7 +118,7 @@ func TestDownloadFromURL_FileExist(t *testing.T) {
 	lowestVersion := "0.1.0"
 
 	url := hashiURL + lowestVersion + "/" + installVersion + lowestVersion + macOS
-	expectedFile := usr.HomeDir + installPath + installVersion + lowestVersion + macOS
+	expectedFile := filepath.Join(usr.HomeDir, installPath, installVersion+lowestVersion+macOS)
 	installedFile, errDownload := lib.DownloadFromURL(installLocation, url)
 
 	if errDownload != nil {
@@ -139,7 +140,7 @@ func TestDownloadFromURL_FileExist(t *testing.T) {
 	latestVersion := "0.11.7"
 
 	url = hashiURL + latestVersion + "/" + installVersion + latestVersion + macOS
-	expectedFile = usr.HomeDir + installPath + installVersion + latestVersion + macOS
+	expectedFile = filepath.Join(usr.HomeDir, installPath, installVersion+latestVersion+macOS)
 	installFile, errDownload = lib.DownloadFromURL(installLocation, url)
 
 	if errDownload != nil {
@@ -176,7 +177,7 @@ func TestInvalidURL(t *testing.T) {
 	}
 
 	fmt.Printf("Current user: %v \n", usr.HomeDir)
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	// create /.terraform.versions_test/ directory to store code
 	if _, err := os.Stat(installLocation); os.IsNotExist(err) {
@@ -189,7 +190,7 @@ func TestInvalidURL(t *testing.T) {
 	}
 
 	url := hashiURL + invalidVersion + "/" + installVersion + invalidVersion + macOS
-	//expectedFile := usr.HomeDir + installPath + installVersion + invalidVersion + macOS
+	//expectedFile :=filepath.Join(usr.HomeDir , installPath, nstallVersion + invalidVersion + macOS)
 	_, errDownload := lib.DownloadFromURL(installLocation, url)
 
 	if errDownload != nil {

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -190,7 +190,7 @@ func TestInvalidURL(t *testing.T) {
 	}
 
 	url := hashiURL + invalidVersion + "/" + installVersion + invalidVersion + macOS
-	//expectedFile :=filepath.Join(usr.HomeDir , installPath, nstallVersion + invalidVersion + macOS)
+	//expectedFile :=filepath.Join(usr.HomeDir, installPath, installVersion + invalidVersion + macOS)
 	_, errDownload := lib.DownloadFromURL(installLocation, url)
 
 	if errDownload != nil {

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -21,8 +21,7 @@ import (
 // TestRenameFile : Create a file, check filename exist,
 // rename file, check new filename exit
 func TestRenameFile(t *testing.T) {
-
-	installFile := "terraform"
+	installFile := lib.ConvertExecutableExt("terraform")
 	installVersion := "terraform_"
 	installPath := "/.terraform.versions_test/"
 	version := "0.0.7"
@@ -31,33 +30,37 @@ func TestRenameFile(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
-	createFile(installLocation + installFile)
+	installFilePath := filepath.Join(installLocation, installFile)
 
-	if exist := checkFileExist(installLocation + installFile); exist {
-		t.Logf("File exist %v", installLocation+installFile)
+	createFile(installFilePath)
+
+	if exist := checkFileExist(installFilePath); exist {
+		t.Logf("File exist %v", installFilePath)
 	} else {
-		t.Logf("File does not exist %v", installLocation+installFile)
+		t.Logf("File does not exist %v", installFilePath)
 		t.Error("Missing file")
 	}
 
-	lib.RenameFile(installLocation+installFile, installLocation+installVersion+version)
+	installVersionFilePath := lib.ConvertExecutableExt(filepath.Join(installLocation, installVersion+version))
 
-	if exist := checkFileExist(installLocation + installVersion + version); exist {
-		t.Logf("New file exist %v", installLocation+installVersion+version)
+	lib.RenameFile(installFilePath, installVersionFilePath)
+
+	if exist := checkFileExist(installVersionFilePath); exist {
+		t.Logf("New file exist %v", installVersionFilePath)
 	} else {
-		t.Logf("New file does not exist %v", installLocation+installVersion+version)
+		t.Logf("New file does not exist %v", installVersionFilePath)
 		t.Error("Missing new file")
 	}
 
-	if exist := checkFileExist(installLocation + installFile); exist {
-		t.Logf("Old file should not exist %v", installLocation+installFile)
+	if exist := checkFileExist(installFilePath); exist {
+		t.Logf("Old file should not exist %v", installFilePath)
 		t.Error("Did not rename file")
 	} else {
-		t.Logf("Old file does not exist %v", installLocation+installFile)
+		t.Logf("Old file does not exist %v", installFilePath)
 	}
 
 	cleanUp(installLocation)
@@ -66,34 +69,35 @@ func TestRenameFile(t *testing.T) {
 // TestRemoveFiles : Create a file, check file exist,
 // remove file, check file does not exist
 func TestRemoveFiles(t *testing.T) {
-
-	installFile := "terraform"
+	installFile := lib.ConvertExecutableExt("terraform")
 	installPath := "/.terraform.versions_test/"
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
-	createFile(installLocation + installFile)
+	installFilePath := filepath.Join(installLocation, installFile)
 
-	if exist := checkFileExist(installLocation + installFile); exist {
-		t.Logf("File exist %v", installLocation+installFile)
+	createFile(installFilePath)
+
+	if exist := checkFileExist(installFilePath); exist {
+		t.Logf("File exist %v", installFilePath)
 	} else {
-		t.Logf("File does not exist %v", installLocation+installFile)
+		t.Logf("File does not exist %v", installFilePath)
 		t.Error("Missing file")
 	}
 
-	lib.RemoveFiles(installLocation + installFile)
+	lib.RemoveFiles(installFilePath)
 
-	if exist := checkFileExist(installLocation + installFile); exist {
-		t.Logf("Old file should not exist %v", installLocation+installFile)
+	if exist := checkFileExist(installFilePath); exist {
+		t.Logf("Old file should not exist %v", installFilePath)
 		t.Error("Did not remove file")
 	} else {
-		t.Logf("Old file does not exist %v", installLocation+installFile)
+		t.Logf("Old file does not exist %v", installFilePath)
 	}
 
 	cleanUp(installLocation)
@@ -102,7 +106,6 @@ func TestRemoveFiles(t *testing.T) {
 // TestUnzip : Create a file, check file exist,
 // remove file, check file does not exist
 func TestUnzip(t *testing.T) {
-
 	installPath := "/.terraform.versions_test/"
 	absPath, _ := filepath.Abs("../test-data/test-data.zip")
 
@@ -112,7 +115,7 @@ func TestUnzip(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
@@ -138,14 +141,13 @@ func TestUnzip(t *testing.T) {
 
 // TestCreateDirIfNotExist : Create a directory, check directory exist
 func TestCreateDirIfNotExist(t *testing.T) {
-
 	installPath := "/.terraform.versions_test/"
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	cleanUp(installLocation)
 
@@ -171,7 +173,6 @@ func TestCreateDirIfNotExist(t *testing.T) {
 
 //TestWriteLines : write to file, check readline to verify
 func TestWriteLines(t *testing.T) {
-
 	installPath := "/.terraform.versions_test/"
 	recentFile := "RECENT"
 	semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}(-\w+\d*)?\z`)
@@ -181,13 +182,14 @@ func TestWriteLines(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
+	recentFilePath := filepath.Join(installLocation, recentFile)
 	test_array := []string{"0.1.1", "0.0.2", "0.0.3", "0.12.0-rc1", "0.12.0-beta1"}
 
-	errWrite := lib.WriteLines(test_array, installLocation+recentFile)
+	errWrite := lib.WriteLines(test_array, recentFilePath)
 
 	if errWrite != nil {
 		t.Logf("Write should work %v (unexpected)", errWrite)
@@ -201,10 +203,9 @@ func TestWriteLines(t *testing.T) {
 			errOpen, errRead error
 			lines            []string
 		)
-		if file, errOpen = os.Open(installLocation + recentFile); errOpen != nil {
+		if file, errOpen = os.Open(recentFilePath); errOpen != nil {
 			log.Fatal(errOpen)
 		}
-		defer file.Close()
 
 		reader := bufio.NewReader(file)
 		buffer := bytes.NewBuffer(make([]byte, 0))
@@ -233,11 +234,11 @@ func TestWriteLines(t *testing.T) {
 			}
 		}
 
+		file.Close()
 		t.Log("Write versions exist (expected)")
 	}
 
 	cleanUp(installLocation)
-
 }
 
 // TestReadLines : read from file, check write to verify
@@ -250,10 +251,11 @@ func TestReadLines(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
+	recentFilePath := filepath.Join(installLocation, recentFile)
 	test_array := []string{"0.0.1", "0.0.2", "0.0.3", "0.12.0-rc1", "0.12.0-beta1"}
 
 	var (
@@ -261,10 +263,9 @@ func TestReadLines(t *testing.T) {
 		errCreate error
 	)
 
-	if file, errCreate = os.Create(installLocation + recentFile); errCreate != nil {
+	if file, errCreate = os.Create(recentFilePath); errCreate != nil {
 		log.Fatalf("Error: %s\n", errCreate)
 	}
-	defer file.Close()
 
 	for _, item := range test_array {
 		_, err := file.WriteString(strings.TrimSpace(item) + "\n")
@@ -274,7 +275,7 @@ func TestReadLines(t *testing.T) {
 		}
 	}
 
-	lines, errRead := lib.ReadLines(installLocation + recentFile)
+	lines, errRead := lib.ReadLines(recentFilePath)
 
 	if errRead != nil {
 		log.Fatalf("Error: %s\n", errRead)
@@ -287,15 +288,14 @@ func TestReadLines(t *testing.T) {
 		}
 	}
 
+	file.Close()
 	t.Log("Read versions exist (expected)")
 
 	cleanUp(installLocation)
-
 }
 
 // TestIsDirEmpty : create empty directory, check if empty
 func TestIsDirEmpty(t *testing.T) {
-
 	current := time.Now()
 
 	installPath := "/.terraform.versions_test/"
@@ -304,18 +304,19 @@ func TestIsDirEmpty(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	test_dir := current.Format("2006-01-02")
+	test_dir_path := filepath.Join(installLocation, test_dir)
 	t.Logf("Create test dir: %v \n", test_dir)
 
 	createDirIfNotExist(installLocation)
 
-	createDirIfNotExist(installLocation + "/" + test_dir)
+	createDirIfNotExist(test_dir_path)
 
-	empty := lib.IsDirEmpty(installLocation + "/" + test_dir)
+	empty := lib.IsDirEmpty(test_dir_path)
 
-	t.Logf("Expected directory to be empty %v [expected]", installLocation+"/"+test_dir)
+	t.Logf("Expected directory to be empty %v [expected]", test_dir_path)
 
 	if empty == true {
 		t.Logf("Directory empty")
@@ -323,33 +324,31 @@ func TestIsDirEmpty(t *testing.T) {
 		t.Error("Directory not empty")
 	}
 
-	cleanUp(installLocation + "/" + test_dir)
-
+	cleanUp(test_dir_path)
 	cleanUp(installLocation)
-
 }
 
 // TestCheckDirHasTGBin : create tg file in directory, check if exist
 func TestCheckDirHasTFBin(t *testing.T) {
-
 	goarch := runtime.GOARCH
 	goos := runtime.GOOS
 	installPath := "/.terraform.versions_test/"
-	installFile := "terraform"
+	installFilePrefix := "terraform"
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
-	createFile(installLocation + installFile + "_" + goos + "_" + goarch)
+	installFileVersionPath := lib.ConvertExecutableExt(filepath.Join(installLocation, installFilePrefix+"_"+goos+"_"+goarch))
+	createFile(installFileVersionPath)
 
-	empty := lib.CheckDirHasTGBin(installLocation, installFile)
+	empty := lib.CheckDirHasTGBin(installLocation, installFilePrefix)
 
-	t.Logf("Expected directory to have tf file %v [expected]", installLocation+installFile+"_"+goos+"_"+goarch)
+	t.Logf("Expected directory to have tf file %v [expected]", installFileVersionPath)
 
 	if empty == true {
 		t.Logf("Directory empty")
@@ -362,23 +361,23 @@ func TestCheckDirHasTFBin(t *testing.T) {
 
 // TestPath : create file in directory, check if path exist
 func TestPath(t *testing.T) {
-
 	installPath := "/.terraform.versions_test"
-	installFile := "terraform"
+	installFile := lib.ConvertExecutableExt("terraform")
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	installLocation := usr.HomeDir + installPath
+	installLocation := filepath.Join(usr.HomeDir, installPath)
 
 	createDirIfNotExist(installLocation)
 
-	createFile(installLocation + "/" + installFile)
+	installFilePath := filepath.Join(installLocation, installFile)
+	createFile(installFilePath)
 
-	path := lib.Path(installLocation + "/" + installFile)
+	path := lib.Path(installFilePath)
 
-	t.Logf("Path created %s\n", installLocation+installFile)
+	t.Logf("Path created %s\n", installFilePath)
 	t.Logf("Path expected %s\n", installLocation)
 	t.Logf("Path from library %s\n", path)
 	if path == installLocation {
@@ -391,7 +390,6 @@ func TestPath(t *testing.T) {
 }
 
 // TestGetFileName : remove file ext.  .tfswitch.config returns .tfswitch
-
 func TestGetFileName(t *testing.T) {
 
 	fileNameWithExt := "file.toml"
@@ -402,5 +400,57 @@ func TestGetFileName(t *testing.T) {
 		t.Logf("File removed extension (expected)")
 	} else {
 		t.Error("File did not remove extension (unexpected)")
+	}
+}
+
+// TestConvertExecutableExt : convert executable binary with extension
+func TestConvertExecutableExt(t *testing.T) {
+	usr, errCurr := user.Current()
+	if errCurr != nil {
+		log.Fatal(errCurr)
+	}
+
+	installPath := "/.terraform.versions_test/"
+	test_array := []string{
+		"terraform",
+		"terraform.exe",
+		filepath.Join(usr.HomeDir, installPath, "terraform"),
+		filepath.Join(usr.HomeDir, installPath, "terraform.exe"),
+	}
+
+	for _, fpath := range test_array {
+		fpathExt := lib.ConvertExecutableExt((fpath))
+		outputMsg := fpath + " converted to " + fpathExt + " on " + runtime.GOOS
+
+		switch runtime.GOOS {
+		case "windows":
+			if filepath.Ext(fpathExt) != ".exe" {
+				t.Error(outputMsg + " (unexpected)")
+				continue
+			}
+
+			if filepath.Ext(fpath) == ".exe" {
+				if fpathExt != fpath {
+					t.Error(outputMsg + " (unexpected)")
+				} else {
+					t.Logf(outputMsg + " (expected)")
+				}
+				continue
+			}
+
+			if fpathExt != fpath+".exe" {
+				t.Error(outputMsg + " (unexpected)")
+				continue
+			}
+
+			t.Logf(outputMsg + " (expected)")
+		default:
+			if fpath != fpathExt {
+				t.Error(outputMsg + " (unexpected)")
+				continue
+			}
+
+			t.Logf(outputMsg + " (expected)")
+		}
 	}
 }

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -195,7 +195,6 @@ func TestWriteLines(t *testing.T) {
 		t.Logf("Write should work %v (unexpected)", errWrite)
 		log.Fatal(errWrite)
 	} else {
-
 		var (
 			file             *os.File
 			part             []byte

--- a/lib/install.go
+++ b/lib/install.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 )
 
@@ -59,7 +60,7 @@ func getInstallLocation() string {
 	}
 
 	/* set installation location */
-	installLocation = usr.HomeDir + installPath
+	installLocation = filepath.Join(usr.HomeDir, installPath)
 
 	/* Create local installation directory if it does not exist */
 	CreateDirIfNotExist(installLocation)
@@ -97,7 +98,8 @@ func Install(tfversion string, binPath string) {
 	}
 
 	/* check if selected version already downloaded */
-	fileExist := CheckFileExist(installLocation + installVersion + tfversion)
+	installFileVersionPath := ConvertExecutableExt(filepath.Join(installLocation, installVersion+tfversion))
+	fileExist := CheckFileExist(installFileVersionPath)
 
 	/* if selected version already exist, */
 	if fileExist {
@@ -110,7 +112,7 @@ func Install(tfversion string, binPath string) {
 		}
 
 		/* set symlink to desired version */
-		CreateSymlink(installLocation+installVersion+tfversion, binPath)
+		CreateSymlink(installFileVersionPath, binPath)
 		fmt.Printf("Switched terraform to version %q \n", tfversion)
 		AddRecent(tfversion) //add to recent file for faster lookup
 		os.Exit(0)
@@ -136,10 +138,11 @@ func Install(tfversion string, binPath string) {
 	}
 
 	/* rename unzipped file to terraform version name - terraform_x.x.x */
-	RenameFile(installLocation+installFile, installLocation+installVersion+tfversion)
+	installFilePath := ConvertExecutableExt(filepath.Join(installLocation, installFile))
+	RenameFile(installFilePath, installFileVersionPath)
 
 	/* remove zipped file to clear clutter */
-	RemoveFiles(installLocation + installVersion + tfversion + "_" + goos + "_" + goarch + ".zip")
+	RemoveFiles(zipFile)
 
 	/* remove current symlink if exist*/
 	symlinkExist := CheckSymlink(binPath)
@@ -149,7 +152,7 @@ func Install(tfversion string, binPath string) {
 	}
 
 	/* set symlink to desired version */
-	CreateSymlink(installLocation+installVersion+tfversion, binPath)
+	CreateSymlink(installFileVersionPath, binPath)
 	fmt.Printf("Switched terraform to version %q \n", tfversion)
 	AddRecent(tfversion) //add to recent file for faster lookup
 	os.Exit(0)
@@ -159,10 +162,11 @@ func Install(tfversion string, binPath string) {
 func AddRecent(requestedVersion string) {
 
 	installLocation = getInstallLocation() //get installation location -  this is where we will put our terraform binary file
+	versionFile := filepath.Join(installLocation, recentFile)
 
-	fileExist := CheckFileExist(installLocation + recentFile)
+	fileExist := CheckFileExist(versionFile)
 	if fileExist {
-		lines, errRead := ReadLines(installLocation + recentFile)
+		lines, errRead := ReadLines(versionFile)
 
 		if errRead != nil {
 			fmt.Printf("Error: %s\n", errRead)
@@ -172,7 +176,7 @@ func AddRecent(requestedVersion string) {
 		for _, line := range lines {
 			if !ValidVersionFormat(line) {
 				fmt.Println("File dirty. Recreating cache file.")
-				RemoveFiles(installLocation + recentFile)
+				RemoveFiles(versionFile)
 				CreateRecentFile(requestedVersion)
 				return
 			}
@@ -185,10 +189,10 @@ func AddRecent(requestedVersion string) {
 				_, lines = lines[len(lines)-1], lines[:len(lines)-1]
 
 				lines = append([]string{requestedVersion}, lines...)
-				WriteLines(lines, installLocation+recentFile)
+				WriteLines(lines, versionFile)
 			} else {
 				lines = append([]string{requestedVersion}, lines...)
-				WriteLines(lines, installLocation+recentFile)
+				WriteLines(lines, versionFile)
 			}
 		}
 
@@ -201,11 +205,12 @@ func AddRecent(requestedVersion string) {
 func GetRecentVersions() ([]string, error) {
 
 	installLocation = getInstallLocation() //get installation location -  this is where we will put our terraform binary file
+	versionFile := filepath.Join(installLocation, recentFile)
 
-	fileExist := CheckFileExist(installLocation + recentFile)
+	fileExist := CheckFileExist(versionFile)
 	if fileExist {
 
-		lines, errRead := ReadLines(installLocation + recentFile)
+		lines, errRead := ReadLines(versionFile)
 		outputRecent := []string{}
 
 		if errRead != nil {
@@ -219,7 +224,7 @@ func GetRecentVersions() ([]string, error) {
 			and the recent file will be removed
 			*/
 			if !ValidVersionFormat(line) {
-				RemoveFiles(installLocation + recentFile)
+				RemoveFiles(versionFile)
 				return nil, errRead
 			}
 
@@ -240,5 +245,18 @@ func CreateRecentFile(requestedVersion string) {
 
 	installLocation = getInstallLocation() //get installation location -  this is where we will put our terraform binary file
 
-	WriteLines([]string{requestedVersion}, installLocation+recentFile)
+	WriteLines([]string{requestedVersion}, filepath.Join(installLocation, recentFile))
+}
+
+//ConvertExecutableExt : convert excutable with local OS extension
+func ConvertExecutableExt(fpath string) string {
+	switch runtime.GOOS {
+	case "windows":
+		if filepath.Ext(fpath) == ".exe" {
+			return fpath
+		}
+		return fpath + ".exe"
+	default:
+		return fpath
+	}
 }

--- a/lib/symlink_test.go
+++ b/lib/symlink_test.go
@@ -1,9 +1,11 @@
-package lib_test
+
+// +build !windows
 
 import (
 	"log"
 	"os"
 	"os/user"
+	"path/filepath"
 	"testing"
 
 	"github.com/warrensbox/terraform-switcher/lib"
@@ -21,8 +23,8 @@ func TestCreateSymlink(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	symlinkPathSrc := usr.HomeDir + testSymlinkSrc
-	symlinkPathDest := usr.HomeDir + testSymlinkDest
+	symlinkPathSrc := filepath.Join(usr.HomeDir, testSymlinkSrc)
+	symlinkPathDest := filepath.Join(usr.HomeDir, testSymlinkDest)
 
 	ln, _ := os.Readlink(symlinkPathSrc)
 
@@ -59,8 +61,8 @@ func TestRemoveSymlink(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	symlinkPathSrc := usr.HomeDir + testSymlinkSrc
-	symlinkPathDest := usr.HomeDir + testSymlinkDest
+	symlinkPathSrc := filepath.Join(usr.HomeDir, testSymlinkSrc)
+	symlinkPathDest := filepath.Join(usr.HomeDir, testSymlinkDest)
 
 	ln, _ := os.Readlink(symlinkPathSrc)
 
@@ -94,8 +96,8 @@ func TestCheckSymlink(t *testing.T) {
 	if errCurr != nil {
 		log.Fatal(errCurr)
 	}
-	symlinkPathSrc := usr.HomeDir + testSymlinkSrc
-	symlinkPathDest := usr.HomeDir + testSymlinkDest
+	symlinkPathSrc := filepath.Join(usr.HomeDir, testSymlinkSrc)
+	symlinkPathDest := filepath.Join(usr.HomeDir, testSymlinkDest)
 
 	ln, _ := os.Readlink(symlinkPathSrc)
 

--- a/lib/symlink_test.go
+++ b/lib/symlink_test.go
@@ -1,5 +1,4 @@
-
-// +build !windows
+package lib_test
 
 import (
 	"log"

--- a/main.go
+++ b/main.go
@@ -337,8 +337,7 @@ func getParamsTOML(binPath string, dir string) (string, string) {
 		os.Exit(1) // exit immediately if config file provided but it is unable to read it
 	}
 
-	bin := viper.Get("bin") // read custom binary location
-
+	bin := viper.Get("bin")                                            // read custom binary location
 	if binPath == lib.ConvertExecutableExt(defaultBin) && bin != nil { // if the bin path is the same as the default binary path and if the custom binary is provided in the toml file (use it)
 		binPath = os.ExpandEnv(bin.(string))
 	}


### PR DESCRIPTION
# Overview

* ♿ changes to make `tfswitch` work on windows;
  * before: fails at `rename` unzipped `terraform` binary to `terraform_<version>`, as windows terraform binary is `terraform.exe` (ends with `exe`)
  * now: installs `terraform` successfully to `$HOME/bin`, when `$HOME/.tfswitch.toml` is defined (with `bin="<%USERPROFILE%>\\bin\\terraform.exe"`) and `tfswitch` is run under `Administrator` Mode
* ✅ fix process holding `RECENT` file issue in `file_test.go` (`TestWriteLines`/`TestReadLines`) cases, this causes os panic;
* ♻️ refactor code use `filepath.Join` instead of concatenating strings manually, avoid duplicated colde on file path through defining variables to store file path;
* 🚀 add ci (`travis.yaml`) on `windows/osx`

https://user-images.githubusercontent.com/4773348/120096838-fbcdd280-c170-11eb-9b94-634412e2fb2f.mp4

## Todo

* on `windows` the `defaultBin    = "/usr/local/bin/terraform"` doesn't exists, and windows have no concept like `/usr/local/bin`, so it's a bit underministic on the `defaultBin` for windows (in this change, it gets converted to `/usr/local/bin/terraform.exe`), hence for windows a `$HOME/.tfswitch.toml` need to exists with minimum content `bin` need to be defined with a valid path, below is an example
```toml
bin = "C:\\Users\\老叶\\bin\\terraform.exe"
```

* `mklink` requires `Administrator` permission to work on windows (with `/D` option), tfswitch must be run under `Administrator` mode on windows to work, or `symLink` permission issue will be thrown, below is an example

```powershell
2021/05/30 15:59:13
                Unable to create new symlink.
                Maybe symlink already exist. Try removing existing symlink manually.
                Try running "unlink C:\Users\老叶\test-tfswitcher-src" to remove existing symlink.
                If error persist, you may not have the permission to create a symlink at C:\Users\老叶\test-tfswitcher-src.
                Error: symlink C:\Users\老叶\test-tfswitcher-dest C:\Users\老叶\test-tfswitcher-src: A required privilege is not held by the client.
```

* `promptui` doesn't work nicely on `windows` on option scrolling, to install earlier version of terraform on windows `tfswitch <version>` is the workaround