### PR TITLE
Install darwin arm64 terraform version when desired version is equal …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ test: $(EXE)
 	mv $(EXE) build
 	go test -v ./...
 
+.PHONY: install
+install: $(EXE)
+	mkdir -p ~/bin
+	mv $(EXE) ~/bin
+
 .PHONY: docs
 docs:
 	cd docs; bundle install --path vendor/bundler; bundle exec jekyll build -c _config.yml; cd ..

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXE  := tfswitch
 PKG  := github.com/warrensbox/terraform-switcher
-VER := $(shell git ls-remote --tags git://github.com/warrensbox/terraform-switcher | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 2 | head -n1)
+VER := $(shell git ls-remote --tags . | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 2 | head -n1)
 PATH := build:$(PATH)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 EXE  := tfswitch
 PKG  := github.com/warrensbox/terraform-switcher
-VER := $(shell git ls-remote --tags . | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 2 | head -n1)
+#VER := $(shell git ls-remote --tags . | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 2 | head -n1)
+VER := $(shell git ls-remote --tags . | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 1)
 PATH := build:$(PATH)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3 // indirect
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/kiranjthomas/terraform-config-inspect v0.0.0-20191120205521-a1d709eb2824

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,7 @@ is_supported_platform() {
   case "$platform" in
     windows/amd64) found=0 ;;
     darwin/amd64) found=0 ;;
+    darwin/arm64) found=0 ;;
     linux/amd64) found=0 ;;
   esac
   return $found

--- a/lib/install.go
+++ b/lib/install.go
@@ -17,7 +17,7 @@ const (
 	installPath    = ".terraform.versions"
 	recentFile     = "RECENT"
 	defaultBin     = "/usr/local/bin/terraform" //default bin installation dir
-	tfDarwinArm64  = "1.0.2"
+	tfDarwinArm64StartVersion  = "1.0.2"
 )
 
 var (

--- a/lib/install.go
+++ b/lib/install.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 	installPath    = ".terraform.versions"
 	recentFile     = "RECENT"
 	defaultBin     = "/usr/local/bin/terraform" //default bin installation dir
+	tfDarwinArm64  = "1.0.2"
 )
 
 var (
@@ -102,8 +104,10 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 	goarch := runtime.GOARCH
 	goos := runtime.GOOS
 
-	// TODO: Workaround for macos arm64 since terraform doesn't have a binary for it yet
-	if goos == "darwin" && goarch == "arm64" {
+	// Terraform darwin arm64 comes with 1.0.2 and next version
+	tfver, _ := version.NewVersion(tfversion)
+	tf102, _ := version.NewVersion(tfDarwinArm64)
+	if goos == "darwin" && goarch == "arm64" && tfver.LessThan(tf102)  {
 		goarch = "amd64"
 	}
 

--- a/lib/install.go
+++ b/lib/install.go
@@ -106,7 +106,7 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 
 	// Terraform darwin arm64 comes with 1.0.2 and next version
 	tfver, _ := version.NewVersion(tfversion)
-	tf102, _ := version.NewVersion(tfDarwinArm64)
+	tf102, _ := version.NewVersion(tfDarwinArm64StartVersion)
 	if goos == "darwin" && goarch == "arm64" && tfver.LessThan(tf102)  {
 		goarch = "amd64"
 	}


### PR DESCRIPTION
…or greater than 1.0.2 and you run MacOS on M1 CPU

Hi this MR is to fix the : 
TODO: Workaround for macos arm64 since terraform doesn't have a binary for it yet
 line 106 of lib/install.go