### PR TITLE
Handle multiple terraform architecture (arm64/amd64) for the same version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXE  := tfswitch
 PKG  := github.com/warrensbox/terraform-switcher
-VER := $(shell git ls-remote --tags git://github.com/warrensbox/terraform-switcher | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 2 | head -n1)
+VER := $(shell git ls-remote --tags https://github.com/warrensbox/terraform-switcher | awk '{print $$2}'| awk -F"/" '{print $$3}' | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -n 2 | head -n1)
 PATH := build:$(PATH)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -11,7 +11,7 @@ $(EXE): go.mod *.go lib/*.go
 .PHONY: release
 release: $(EXE) darwin linux
 
-.PHONY: darwin linux 
+.PHONY: darwin linux
 darwin linux:
 	GOOS=$@ go build -ldflags "-X main.version=$(VER)" -o $(EXE)-$(VER)-$@-$(GOARCH) $(PKG)
 
@@ -32,4 +32,3 @@ install: $(EXE)
 .PHONY: docs
 docs:
 	cd docs; bundle install --path vendor/bundler; bundle exec jekyll build -c _config.yml; cd ..
-

--- a/lib/install.go
+++ b/lib/install.go
@@ -76,7 +76,7 @@ func GetInstallLocation() string {
 }
 
 //Install : Install the provided version in the argument
-func Install(tfversion string, binPath string, mirrorURL string) {
+func Install(tfArch *string, tfversion string, binPath string, mirrorURL string) {
 
 	// if !ValidVersionFormat(tfversion) {
 	// 	fmt.Printf("The provided terraform version format does not exist - %s. Try `tfswitch -l` to see all available versions.\n", tfversion)
@@ -101,6 +101,8 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 	tf102, _ := version.NewVersion(tfDarwinArm64StartVersion)
 	if goos == "darwin" && goarch == "arm64" && tfver.LessThan(tf102) {
 		goarch = "amd64"
+	} else {
+		goarch = *tfArch
 	}
 
 	/* check if selected version already downloaded */
@@ -120,7 +122,7 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 		/* set symlink to desired version */
 		CreateSymlink(installFileVersionPath, binPath)
 		fmt.Printf("Switched terraform to version %q \n", tfversion)
-		AddRecent(tfversion) //add to recent file for faster lookup
+		AddRecent(tfversion + "-" + goarch) //add to recent file for faster lookup
 		os.Exit(0)
 	}
 
@@ -166,7 +168,7 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 	/* set symlink to desired version */
 	CreateSymlink(installFileVersionPath, binPath)
 	fmt.Printf("Switched terraform to version %q \n", tfversion)
-	AddRecent(tfversion) //add to recent file for faster lookup
+	AddRecent(tfversion + "-" + goarch) //add to recent file for faster lookup
 	os.Exit(0)
 }
 

--- a/lib/install.go
+++ b/lib/install.go
@@ -104,7 +104,7 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 	}
 
 	/* check if selected version already downloaded */
-	installFileVersionPath := ConvertExecutableExt(filepath.Join(installLocation, versionPrefix+tfversion))
+	installFileVersionPath := ConvertExecutableExt(filepath.Join(installLocation, versionPrefix+tfversion+"-"+goarch))
 	fileExist := CheckFileExist(installFileVersionPath)
 
 	/* if selected version already exist, */

--- a/lib/install.go
+++ b/lib/install.go
@@ -121,7 +121,7 @@ func Install(tfArch *string, tfversion string, binPath string, mirrorURL string)
 
 		/* set symlink to desired version */
 		CreateSymlink(installFileVersionPath, binPath)
-		fmt.Printf("Switched terraform to version %q \n", tfversion)
+		fmt.Printf("Switched terraform to version %q (%s)\n", tfversion, goarch)
 		AddRecent(tfversion + "-" + goarch) //add to recent file for faster lookup
 		os.Exit(0)
 	}
@@ -167,7 +167,7 @@ func Install(tfArch *string, tfversion string, binPath string, mirrorURL string)
 
 	/* set symlink to desired version */
 	CreateSymlink(installFileVersionPath, binPath)
-	fmt.Printf("Switched terraform to version %q \n", tfversion)
+	fmt.Printf("Switched terraform to version %q (%s)\n", tfversion, goarch)
 	AddRecent(tfversion + "-" + goarch) //add to recent file for faster lookup
 	os.Exit(0)
 }

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"reflect"
 	"regexp"
 	"strings"
 )
@@ -140,22 +139,14 @@ func GetTFURLBody(mirrorURL string) ([]string, error) {
 }
 
 //VersionExist : check if requested version exist
-func VersionExist(val interface{}, array interface{}) (exists bool) {
-
-	exists = false
-	switch reflect.TypeOf(array).Kind() {
-	case reflect.Slice:
-		s := reflect.ValueOf(array)
-
-		for i := 0; i < s.Len(); i++ {
-			if reflect.DeepEqual(val, s.Index(i).Interface()) == true {
-				exists = true
-				return exists
-			}
+func VersionExist(val string, array []string) (exists bool) {
+	for _, v := range array {
+		if v == val {
+			return true
 		}
 	}
 
-	return exists
+	return false
 }
 
 //RemoveDuplicateVersions : remove duplicate version

--- a/main.go
+++ b/main.go
@@ -420,7 +420,14 @@ func installOption(tfArch *string, listAll bool, custBinPath, mirrorURL *string)
 	}
 
 	_, tfversion, errPrompt := prompt.Run()
+
 	tfversion = strings.Trim(tfversion, " *recent") //trim versions with the string " *recent" appended
+
+	if strings.Contains(tfversion, "-") {
+		tfversionSplitted := strings.SplitN(tfversion, "-", 2)
+		tfversion = tfversionSplitted[0]
+		tfArch = &tfversionSplitted[1]
+	}
 
 	if errPrompt != nil {
 		log.Printf("Prompt failed %v\n", errPrompt)

--- a/main.go
+++ b/main.go
@@ -289,7 +289,7 @@ func installVersion(tfArch *string, arg string, custBinPath *string, mirrorURL *
 		recentDownloadFile := lib.CheckFileExist(installFileVersionPath)
 		if recentDownloadFile {
 			lib.ChangeSymlink(installFileVersionPath, *custBinPath)
-			fmt.Printf("Switched terraform to version %q \n", requestedVersion)
+			fmt.Printf("Switched terraform to version %q (%s)\n", requestedVersion, *tfArch)
 			lib.AddRecent(requestedVersion + "-" + *tfArch) //add to recent file for faster lookup
 			os.Exit(0)
 		}


### PR DESCRIPTION
We use multiple version of terraform in arch amd64 and arm64.

With recent terraform stacks, no problem, we can run all terraform/provider as arm64 binaries, but for older stacks, that use unmaintained provider (available only as amd64), we need to run terraform as amd64 (via rosetta 2) ...

In this last case, tfswitch don't download terraform again because the version already exist in ~/.terraform.versions ... but with bad arch.

The proposed patch add the architecture to the terraform binary name to be able to have an arm64 and amd64 version of the same terraform version and let the user choose a specific architecture for terraform (with the new -a / --arch parameter).