### PR TITLE
MacOs -> macOS to be consistent with the standard casing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,7 +73,7 @@ brews:
 
     # Caveats for the user of your binary.
     # Default is empty.
-    caveats: "Type 'tfswitch' on your command line and choose the terraform version that you want from the dropdown. This command currently only works on MacOs and Linux"
+    caveats: "Type 'tfswitch' on your command line and choose the terraform version that you want from the dropdown. This command currently only works on macOS and Linux"
 
     # Your app's homepage.
     # Default is empty.


### PR DESCRIPTION
Just happened to notice this today. 

The 's' being lowercase instead of uppercase is what caught my eye, but apparently the 'm' is supposed to be lowercase.