### PR TITLE
Revert "Automate binary tests from test-data directory"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
             go test -v ./...
             mkdir -p build
             go build -v -o build/tfswitch
-            find ./test-data/* -type d | xargs -n 1 ./build/tfswitch -c
 
   release:
     docker:

--- a/test-data/test_tfswitchtoml/.tfswitch.toml
+++ b/test-data/test_tfswitchtoml/.tfswitch.toml
@@ -1,2 +1,2 @@
-bin = "/usr/local/bin/terraform"
+bin = "/Users/warrenveerasingam/bin/terraform"
 version = "0.11.3"


### PR DESCRIPTION
Reverts warrensbox/terraform-switcher#234 to fix CircleCI build since #235 requires unexpected number of approving reviews which I can't fulfill on my own.