### PR TITLE
:bug: Corrected bad installations if user doesn't input 2 dots in ver…

### DIFF
--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -73,7 +73,6 @@ func GetTFLatest(mirrorURL string) (string, error) {
 
 //GetTFLatestImplicit :  Get the latest implicit terraform version given the hashicorp url
 func GetTFLatestImplicit(mirrorURL string, preRelease bool, version string) (string, error) {
-
 	if preRelease == true {
 		//TODO: use GetTFList() instead of GetTFURLBody
 		versions, error := GetTFURLBody(mirrorURL)
@@ -94,6 +93,9 @@ func GetTFLatestImplicit(mirrorURL string, preRelease bool, version string) (str
 			}
 		}
 	} else if preRelease == false {
+		if strings.Count(version, string(".")) == 1 {
+			version += ".0"
+		}
 		listAll := false
 		tflist, _ := GetTFList(mirrorURL, listAll) //get list of versions
 		version = fmt.Sprintf("~> %v", version)

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -93,9 +93,6 @@ func GetTFLatestImplicit(mirrorURL string, preRelease bool, version string) (str
 			}
 		}
 	} else if preRelease == false {
-		if strings.Count(version, string(".")) == 1 {
-			version += ".0"
-		}
 		listAll := false
 		tflist, _ := GetTFList(mirrorURL, listAll) //get list of versions
 		version = fmt.Sprintf("~> %v", version)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	listAllFlag := getopt.BoolLong("list-all", 'l', "List all versions of terraform - including beta and rc")
 	latestPre := getopt.StringLong("latest-pre", 'p', defaultLatest, "Latest pre-release implicit version. Ex: tfswitch --latest-pre 0.13 downloads 0.13.0-rc1 (latest)")
 	showLatestPre := getopt.StringLong("show-latest-pre", 'P', defaultLatest, "Show latest pre-release implicit version. Ex: tfswitch --show-latest-pre 0.13 prints 0.13.0-rc1 (latest)")
-	latestStable := getopt.StringLong("latest-stable", 's', defaultLatest, "Latest implicit version. Ex: tfswitch --latest-stable 0.13 downloads 0.13.7 (latest)")
+	latestStable := getopt.StringLong("latest-stable", 's', defaultLatest, "Latest implicit version based on a constraint. Ex: tfswitch --latest-stable 0.13.0 downloads 0.13.7 and 0.13 downloads 0.15.5 (latest)")
 	showLatestStable := getopt.StringLong("show-latest-stable", 'S', defaultLatest, "Show latest implicit version. Ex: tfswitch --show-latest-stable 0.13 prints 0.13.7 (latest)")
 	latestFlag := getopt.BoolLong("latest", 'u', "Get latest stable version")
 	showLatestFlag := getopt.BoolLong("show-latest", 'U', "Show latest stable version")


### PR DESCRIPTION
…sion

The constraint with only one dot returns the first version in the list, the last published.

Steps to reproduce : 
* Check the different outputs of these 2 commands :
```
tfswitch -s 1.0
tfswitch -s 1.0.0
```
Indeed, `tfswitch -s 1.0` downloads terraform v 1.2.2 (at the day I'm writing this) but the tfswitch --help documentation about the flag -s or --latest-stable show that it downloads 0.13.7 when you input 0.13