### PR TITLE
adjust regex to get all terraform versinos from mirror

### DIFF
--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -27,7 +27,7 @@ func GetTFList(mirrorURL string, preRelease bool) ([]string, error) {
 	var semver string
 	if preRelease == true {
 		// Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
-		semver = `\/(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?"`
+		semver = `\/(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?/?"`
 	} else if preRelease == false {
 		// Getting versions from body; should return match /X.X.X/ where X is a number
 		// without the ending '"' pre-release folders would be tried and break.


### PR DESCRIPTION
This fixes https://github.com/warrensbox/terraform-switcher/issues/250 and broken unit tests.