### PR TITLE
Add Linux ARMv{6,7} arch to `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,8 @@ is_supported_platform() {
     darwin/arm64) found=0 ;;
     linux/amd64) found=0 ;;
     linux/arm64) found=0 ;;
+    linux/armv6) found=0 ;;
+    linux/armv7) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
- As seen from #260 Linux ARMv{6,7} are missing from `install.sh`
  despite binaries are built for these platforms in recent releases, so
  add these two to the pool.