### PR TITLE
Update gopkg.in/yaml.v3 version to address CVE-2022-28948

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,5 +35,5 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Version 3.0.0 of gopkg.in/yaml.v3 has the following high CVE:
- https://nvd.nist.gov/vuln/detail/CVE-2022-28948
- https://avd.aquasec.com/nvd/cve-2022-28948

This has been addresses in release 3.0.1. This PR is to bump the version containing the required fix.

Disclosure - I have not been able to test this change locally. I've some more work I need to so on my local golang setup. 

