### PR TITLE
Default version flag added

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ tfswitch -c terraform_dir
 To install from a remote mirror other than the default(https://releases.hashicorp.com/terraform). Use the `-m` or `--mirror` parameter.    
 Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp`
 
+### Set a default TF version to pick
+1. Help the CI systems to default to a version in case version is not detected from above steps.
+2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` in case no other versions could be detected.
+3. Hit **Enter** to install.
+
 ## Automation
 **Automatically switch with bash**
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 	mirrorURL := getopt.StringLong("mirror", 'm', defaultMirror, "Install from a remote API other than the default. Default: "+defaultMirror)
 	chDirPath := getopt.StringLong("chdir", 'c', dir, "Switch to a different working directory before executing the given command. Ex: tfswitch --chdir terraform_project will run tfswitch in the terraform_project directory")
 	versionFlag := getopt.BoolLong("version", 'v', "Displays the version of tfswitch")
+	defaultVersion := getopt.StringLong("default", 'd', defaultLatest, "Default to version to pick up. Ex: tfswitch --default 1.2.4")
 	helpFlag := getopt.BoolLong("help", 'h', "Displays help message")
 	_ = versionFlag
 
@@ -210,6 +211,10 @@ func main() {
 		tfversion := os.Getenv("TF_VERSION")
 		fmt.Printf("Terraform version environment variable: %s\n", tfversion)
 		installVersion(tfversion, custBinPath, mirrorURL)
+
+	/* if default version is provided - Pick this instead of going for prompt */
+	case *defaultVersion != "":
+		installVersion(*defaultVersion, custBinPath, mirrorURL)
 
 	// if no arg is provided
 	default:

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	mirrorURL := getopt.StringLong("mirror", 'm', defaultMirror, "Install from a remote API other than the default. Default: "+defaultMirror)
 	chDirPath := getopt.StringLong("chdir", 'c', dir, "Switch to a different working directory before executing the given command. Ex: tfswitch --chdir terraform_project will run tfswitch in the terraform_project directory")
 	versionFlag := getopt.BoolLong("version", 'v', "Displays the version of tfswitch")
-	defaultVersion := getopt.StringLong("default", 'd', defaultLatest, "Default to version to pick up. Ex: tfswitch --default 1.2.4")
+	defaultVersion := getopt.StringLong("default", 'd', defaultLatest, "Default to this version in case no other versions could be detected. Ex: tfswitch --default 1.2.4")
 	helpFlag := getopt.BoolLong("help", 'h', "Displays help message")
 	_ = versionFlag
 


### PR DESCRIPTION
This flag will allow us to specify a default version to install which will be useful for the CI systems instead of going into the prompt 