### PR TITLE
:zap: improve find terraform bin path

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -94,7 +94,7 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 	 * Tell users to add $HOME/bin to their path
 	 */
 	binPath = InstallableBinLocation(binPath)
-	initialize(binPath) //initialize path
+	initialize(binPath)                    //initialize path
 	installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 
 	goarch := runtime.GOARCH
@@ -280,7 +280,6 @@ func ConvertExecutableExt(fpath string) string {
 // InstallableBinLocation : Checks if terraform is installable in the location provided by the user.
 // If not, create $HOME/bin. Ask users to add  $HOME/bin to $PATH and return $HOME/bin as install location
 func InstallableBinLocation(userBinPath string) string {
-
 	usr, errCurr := user.Current()
 	if errCurr != nil {
 		log.Fatal(errCurr)
@@ -289,15 +288,12 @@ func InstallableBinLocation(userBinPath string) string {
 	binDir := Path(userBinPath)           //get path directory from binary path
 	binPathExist := CheckDirExist(binDir) //the default is /usr/local/bin but users can provide custom bin locations
 
-	if binPathExist == true { //if bin path exist - check if we can write to to it
+	if binPathExist { //if bin path exist - check if we can write to to it
 
-		binPathWritable := false //assume bin path is not writable
-		if runtime.GOOS != "windows" {
-			binPathWritable = CheckDirWritable(binDir) //check if is writable on ( only works on LINUX)
-		}
+		binPathWritable := CheckDirWritable(binDir) //assume bin path is not writable
 
 		// IF: "/usr/local/bin" or `custom bin path` provided by user is non-writable, (binPathWritable == false), we will attempt to install terraform at the ~/bin location. See ELSE
-		if binPathWritable == false {
+		if !binPathWritable {
 
 			homeBinExist := CheckDirExist(filepath.Join(usr.HomeDir, "bin")) //check to see if ~/bin exist
 			if homeBinExist {                                                //if ~/bin exist, install at ~/bin/terraform

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -1,27 +1,94 @@
 package lib
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"os"
 )
 
-//CreateSymlink : create symlink
+// CopyFile copies a file from src to dst. If src and dst files exist, and are
+// the same, then return success. Otherise, attempt to create a hard link
+// between the two files. If that fail, copy the file contents from src to dst.
+func CopyFile(src, dst string) (err error) {
+	sfi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if !sfi.Mode().IsRegular() {
+		// cannot copy non-regular files (e.g., directories,
+		// symlinks, devices, etc.)
+		return fmt.Errorf("CopyFile: non-regular source file %s (%q)", sfi.Name(), sfi.Mode().String())
+	}
+	dfi, err := os.Stat(dst)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return
+		}
+	} else {
+		if !(dfi.Mode().IsRegular()) {
+			return fmt.Errorf("CopyFile: non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
+		}
+		if os.SameFile(sfi, dfi) {
+			return
+		}
+	}
+	if err = os.Link(src, dst); err == nil {
+		return
+	}
+	err = copyFileContents(src, dst)
+	return
+}
+
+// copyFileContents copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file.
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return
+	}
+	err = out.Sync()
+	return
+}
+
+// CreateSymlink : create symlink
 func CreateSymlink(cwd string, dir string) {
 
 	err := os.Symlink(cwd, dir)
 	if err != nil {
-		log.Fatalf(`
-		Unable to create new symlink.
-		Maybe symlink already exist. Try removing existing symlink manually.
-		Try running "unlink %s" to remove existing symlink.
-		If error persist, you may not have the permission to create a symlink at %s.
-		Error: %s
-		`, dir, dir, err)
-		os.Exit(1)
+		log.Println("Unable to create symlink. Trying to copy file (os without symlink permissions)")
+
+		err := CopyFile(cwd, dir)
+		if err != nil {
+			log.Fatalf(`
+			Unable to create new symlink or copy file.
+			Maybe symlink or file already exist. Try removing existing symlink or file manually.
+			Try running "unlink %s" to remove existing symlink or "rm %s" to remove existing file.
+			If error persist, you may not have the permission to create a symlink or file at %s.
+			Error: %s
+			`, dir, dir, dir, err)
+			os.Exit(1)
+		}
 	}
 }
 
-//RemoveSymlink : remove symlink
+// RemoveSymlink : remove symlink
 func RemoveSymlink(symlinkPath string) {
 
 	_, err := os.Lstat(symlinkPath)
@@ -55,7 +122,11 @@ func CheckSymlink(symlinkPath string) bool {
 
 	fi, err := os.Lstat(symlinkPath)
 	if err != nil {
-		return false
+		if _, err := os.Stat(symlinkPath); err == nil {
+			return true
+		} else {
+			return false
+		}
 	}
 
 	if fi.Mode()&os.ModeSymlink != 0 {
@@ -67,7 +138,7 @@ func CheckSymlink(symlinkPath string) bool {
 
 // ChangeSymlink : move symlink to existing binary
 func ChangeSymlink(binVersionPath string, binPath string) {
-
+	fmt.Println("ca passe la - ChangeSymlink")
 	//installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 	binPath = InstallableBinLocation(binPath)
 

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -7,10 +7,10 @@ import (
 	"os"
 )
 
-// CopyFile copies a file from src to dst. If src and dst files exist, and are
+// copyFile copies a file from src to dst. If src and dst files exist, and are
 // the same, then return success. Otherise, attempt to create a hard link
 // between the two files. If that fail, copy the file contents from src to dst.
-func CopyFile(src, dst string) (err error) {
+func copyFile(src, dst string) (err error) {
 	sfi, err := os.Stat(src)
 	if err != nil {
 		return
@@ -18,7 +18,7 @@ func CopyFile(src, dst string) (err error) {
 	if !sfi.Mode().IsRegular() {
 		// cannot copy non-regular files (e.g., directories,
 		// symlinks, devices, etc.)
-		return fmt.Errorf("CopyFile: non-regular source file %s (%q)", sfi.Name(), sfi.Mode().String())
+		return fmt.Errorf("copyFile: non-regular source file %s (%q)", sfi.Name(), sfi.Mode().String())
 	}
 	dfi, err := os.Stat(dst)
 	if err != nil {
@@ -27,7 +27,7 @@ func CopyFile(src, dst string) (err error) {
 		}
 	} else {
 		if !(dfi.Mode().IsRegular()) {
-			return fmt.Errorf("CopyFile: non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
+			return fmt.Errorf("copyFile: non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
 		}
 		if os.SameFile(sfi, dfi) {
 			return
@@ -74,7 +74,7 @@ func CreateSymlink(cwd string, dir string) {
 	if err != nil {
 		log.Println("Unable to create symlink. Trying to copy file (os without symlink permissions)")
 
-		err := CopyFile(cwd, dir)
+		err := copyFile(cwd, dir)
 		if err != nil {
 			log.Fatalf(`
 			Unable to create new symlink or copy file.
@@ -138,7 +138,6 @@ func CheckSymlink(symlinkPath string) bool {
 
 // ChangeSymlink : move symlink to existing binary
 func ChangeSymlink(binVersionPath string, binPath string) {
-	fmt.Println("ca passe la - ChangeSymlink")
 	//installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 	binPath = InstallableBinLocation(binPath)
 


### PR DESCRIPTION
By default, tfswitch will look for the last terraform binary path present in current PATH. This behaviour is ok but can take so munch time and time consuming when working with many Terraform versions.

If the user specifies the binary path (--bin flag), this path is checked before using default behaviour
