### PR TITLE
Feature/add fallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ tfswitch -c terraform_dir
 To install from a remote mirror other than the default(https://releases.hashicorp.com/terraform). Use the `-m` or `--mirror` parameter.    
 Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp`
 
-### Set a default TF version to pick
-1. Help the CI systems to default to a version in case version is not detected from above steps.
-2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` in case no other versions could be detected.
+### Set a default TF version for CICD pipeline
+1. When using a CICD pipeline, you may want a default or fallback version to avoid the pipe from hanging.
+2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` when no other versions could be detected.
 3. Hit **Enter** to install.
+[Also, see CICD example](#cicd)
 
 ## Automation
 **Automatically switch with bash**
@@ -244,7 +245,7 @@ function switch_terraform --on-event fish_postexec
     end
 end
 ```
-
+## CICD
 ### Jenkins setup
 <img src="https://s3.us-east-2.amazonaws.com/kepler-images/warrensbox/tfswitch/jenkins_tfswitch.png" alt="drawing" style="width: 170px;"/>
 
@@ -263,6 +264,10 @@ CUSTOMBIN=`pwd`/.bin            #set custom bin path
 export PATH=$PATH:$CUSTOMBIN    #Add custom bin path to PATH environment
 
 $CUSTOMBIN/tfswitch -b $CUSTOMBIN/terraform 0.11.7 #or simply tfswitch -b $CUSTOMBIN/terraform 0.11.7
+
+#OR 
+
+$CUSTOMBIN/tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform  #or simply tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform 
 
 terraform -v                    #testing version
 ```
@@ -305,6 +310,9 @@ jobs:
 
             $CUSTOMBIN/tfswitch -b $CUSTOMBIN/terraform 0.11.7 #or simply tfswitch -b $CUSTOMBIN/terraform 0.11.7
 
+            #OR
+            $CUSTOMBIN/tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform  #or simply tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform 
+            
             terraform -v                    #testing version
 ```
 ## Order of precedence

--- a/README.md
+++ b/README.md
@@ -170,9 +170,8 @@ To install from a remote mirror other than the default(https://releases.hashicor
 Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp`
 
 ### Set a default TF version for CICD pipeline
-1. When using a CICD pipeline, you may want a default or fallback version to avoid the pipe from hanging.
+1. When using a CICD pipeline, you may want a default or fallback version to avoid the pipeline from hanging.
 2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` when no other versions could be detected.
-3. Hit **Enter** to install.
 [Also, see CICD example](#cicd)
 
 ## Automation

--- a/www/docs/Continuous-Integration.md
+++ b/www/docs/Continuous-Integration.md
@@ -17,6 +17,9 @@ export PATH=$PATH:$CUSTOMBIN    #Add custom bin path to PATH environment
 
 $CUSTOMBIN/tfswitch -b $CUSTOMBIN/terraform 0.11.7 #or simply tfswitch -b $CUSTOMBIN/terraform 0.11.7
 
+#OR 
+$CUSTOMBIN/tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform  #or simply tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform 
+
 terraform -v                    #testing version
 ```
 
@@ -57,6 +60,9 @@ jobs:
             export PATH=$PATH:$CUSTOMBIN    #Add custom bin path to PATH environment
 
             $CUSTOMBIN/tfswitch -b $CUSTOMBIN/terraform 0.11.7 #or simply tfswitch -b $CUSTOMBIN/terraform 0.11.7
+            
+            #OR 
+            $CUSTOMBIN/tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform  #or simply tfswitch -d 0.11.7 -b $CUSTOMBIN/terraform 
 
             terraform -v                    #testing version
 ```

--- a/www/docs/Quick-Start.md
+++ b/www/docs/Quick-Start.md
@@ -118,6 +118,11 @@ tfswitch -c terraform_dir
 To install from a remote mirror other than the default(https://releases.hashicorp.com/terraform). Use the `-m` or `--mirror` parameter.    
 Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp`
 
+### Set a default TF version for CICD pipeline
+1. When using a CICD pipeline, you may want a default or fallback version to avoid the pipeline from hanging.
+2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` when no other versions could be detected.
+[Also, see CICD example](../continuous-integration)
+
 **Automatically switch with bash**
 
 Add the following to the end of your `~/.bashrc` file:


### PR DESCRIPTION
## Context
When using a CICD pipeline, you may want a default or fallback version to avoid the pipeline from hanging.

### Upgrade
N/A

### Added
N/A

### Removed
N/A

### Fixes:
#275 #150 #165 #108
