### PR TITLE
Updating "x/text" to prevent CVE-2022-32149

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/zclconf/go-cty v1.1.0 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.7.0 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0 // indirect


### PR DESCRIPTION
golang.org/x/text 0.3.7 version is vulnerable. (HIGH) I did the necessary changes as the latest version (0.7.0)

CVE-2022-32149 --  https://avd.aquasec.com/nvd/cve-2022-32149