### PR TITLE
feat: allow to show required by module version explicitly

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -13,6 +13,10 @@ import (
 )
 
 const (
+	RecentSuffix = " *recent"
+)
+
+const (
 	installFile               = "terraform"
 	versionPrefix             = "terraform_"
 	installPath               = ".terraform.versions"
@@ -75,7 +79,7 @@ func GetInstallLocation() string {
 
 }
 
-//Install : Install the provided version in the argument
+// Install : Install the provided version in the argument
 func Install(tfversion string, binPath string, mirrorURL string) {
 
 	// if !ValidVersionFormat(tfversion) {
@@ -243,7 +247,7 @@ func GetRecentVersions() ([]string, error) {
 			/* 	output can be confusing since it displays the 3 most recent used terraform version
 			append the string *recent to the output to make it more user friendly
 			*/
-			outputRecent = append(outputRecent, fmt.Sprintf("%s *recent", line))
+			outputRecent = append(outputRecent, fmt.Sprintf("%s%s", line, RecentSuffix))
 		}
 
 		return outputRecent, nil
@@ -252,7 +256,7 @@ func GetRecentVersions() ([]string, error) {
 	return nil, nil
 }
 
-//CreateRecentFile : create a recent file
+// CreateRecentFile : create a recent file
 func CreateRecentFile(requestedVersion string) {
 
 	installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
@@ -260,7 +264,7 @@ func CreateRecentFile(requestedVersion string) {
 	WriteLines([]string{requestedVersion}, filepath.Join(installLocation, recentFile))
 }
 
-//ConvertExecutableExt : convert excutable with local OS extension
+// ConvertExecutableExt : convert excutable with local OS extension
 func ConvertExecutableExt(fpath string) string {
 	switch runtime.GOOS {
 	case "windows":
@@ -273,8 +277,8 @@ func ConvertExecutableExt(fpath string) string {
 	}
 }
 
-//InstallableBinLocation : Checks if terraform is installable in the location provided by the user.
-//If not, create $HOME/bin. Ask users to add  $HOME/bin to $PATH and return $HOME/bin as install location
+// InstallableBinLocation : Checks if terraform is installable in the location provided by the user.
+// If not, create $HOME/bin. Ask users to add  $HOME/bin to $PATH and return $HOME/bin as install location
 func InstallableBinLocation(userBinPath string) string {
 
 	usr, errCurr := user.Current()

--- a/lib/semver.go
+++ b/lib/semver.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	semver "github.com/hashicorp/go-version"
@@ -12,7 +13,7 @@ func GetSemver(tfconstraint *string, mirrorURL *string) (string, error) {
 
 	listAll := true
 	tflist, _ := GetTFList(*mirrorURL, listAll) //get list of versions
-	fmt.Printf("Reading required version from constraint: %s\n", *tfconstraint)
+	fmt.Fprintf(os.Stderr, "Reading required version from constraint: %s\n", *tfconstraint)
 	tfversion, err := SemVerParser(tfconstraint, tflist)
 	return tfversion, err
 }
@@ -39,7 +40,7 @@ func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 	for _, element := range versions {
 		if constraints.Check(element) { // Validate a version against a constraint
 			tfversion = element.String()
-			fmt.Printf("Matched version: %s\n", tfversion)
+			fmt.Fprintf(os.Stderr, "Matched version: %s\n", tfversion)
 			if ValidVersionFormat(tfversion) { //check if version format is correct
 				return tfversion, nil
 			}
@@ -52,10 +53,10 @@ func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 
 // Print invalid TF version
 func PrintInvalidTFVersion() {
-	fmt.Println("Version does not exist or invalid terraform version format.\n Format should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n For example, 0.11.7 and 0.11.9-beta1 are valid versions")
+	fmt.Fprintln(os.Stderr, "Version does not exist or invalid terraform version format.\n Format should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n For example, 0.11.7 and 0.11.9-beta1 are valid versions")
 }
 
 // Print invalid TF version
 func PrintInvalidMinorTFVersion() {
-	fmt.Println("Invalid minor terraform version format. Format should be #.# where # are numbers. For example, 0.11 is valid version")
+	fmt.Fprintln(os.Stderr, "Invalid minor terraform version format. Format should be #.# where # are numbers. For example, 0.11 is valid version")
 }

--- a/main.go
+++ b/main.go
@@ -456,7 +456,7 @@ func installOption(listAll bool, custBinPath, mirrorURL *string) {
 func installTFProvidedModule(dir string, custBinPath, mirrorURL *string) {
 	fmt.Println("Reading required version from terraform file")
 	module, _ := tfconfig.LoadModule(dir)
-	if len(module.RequiredCore) >= 1 {
+	if len(module.RequiredCore) == 0 {
 		fmt.Println("The provided directory does not have required terraform version constraint.")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -378,10 +378,7 @@ func checkTFModuleFileExist(dir string) bool {
 // checkTFEnvExist - checks if the TF_VERSION environment variable is set
 func checkTFEnvExist() bool {
 	tfversion := os.Getenv("TF_VERSION")
-	if tfversion != "" {
-		return true
-	}
-	return false
+	return tfversion != ""
 }
 
 /* parses everything in the toml file, return required version and bin path */
@@ -444,7 +441,7 @@ func installOption(listAll bool, custBinPath, mirrorURL *string) {
 	}
 
 	_, tfversion, errPrompt := prompt.Run()
-	tfversion = strings.Trim(tfversion, " *recent") //trim versions with the string " *recent" appended
+	tfversion = strings.TrimPrefix(tfversion, lib.RecentSuffix) // trim versions with the string " *recent" appended
 
 	if errPrompt != nil {
 		log.Printf("Prompt failed %v\n", errPrompt)
@@ -506,8 +503,5 @@ func checkVersionDefinedHCL(tgFile *string) bool {
 	}
 	var version terragruntVersionConstraints
 	gohcl.DecodeBody(file.Body, nil, &version)
-	if version == (terragruntVersionConstraints{}) {
-		return false
-	}
-	return true
+	return version != (terragruntVersionConstraints{})
 }

--- a/main.go
+++ b/main.go
@@ -294,7 +294,7 @@ func showLatestRequiredVersion(dir string, custBinPath, mirrorURL *string) {
 		fmt.Fprintln(os.Stderr, "The provided directory does not have required terraform version constraint.")
 		os.Exit(1)
 	}
-	tfconstraint := strings.Join(module.RequiredCore, ", ")
+	tfconstraint := module.RequiredCore[0] // we skip duplicated definitions and use only first one
 	tfversion, err := lib.GetSemver(&tfconstraint, mirrorURL)
 	if err == nil {
 		fmt.Printf("%s\n", tfversion)
@@ -365,11 +365,14 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-// fileExists checks if a file exists and is not a directory before we
+// checkTFModuleFileExist checks if a file exists and is not a directory before we
 // try using it to prevent further errors.
 func checkTFModuleFileExist(dir string) bool {
-	module, _ := tfconfig.LoadModule(dir)
-	return len(module.RequiredCore) >= 1
+	if tfconfig.IsModuleDir(dir) {
+		module, _ := tfconfig.LoadModule(dir)
+		return len(module.RequiredCore) > 0
+	}
+	return false
 }
 
 // checkTFEnvExist - checks if the TF_VERSION environment variable is set
@@ -460,7 +463,7 @@ func installTFProvidedModule(dir string, custBinPath, mirrorURL *string) {
 		fmt.Println("The provided directory does not have required terraform version constraint.")
 		os.Exit(1)
 	}
-	tfconstraint := strings.Join(module.RequiredCore, ", ")
+	tfconstraint := module.RequiredCore[0] //we skip duplicated definitions and use only first one
 	installFromConstraint(&tfconstraint, custBinPath, mirrorURL)
 }
 


### PR DESCRIPTION
Proposed changes simplify the possibility to use `tfswitch` in automation: my own use-case is to fetch the required by project terraform version and to use specific version of docker image with terraform inside the CI/CD pipeline.

Related diagnostic messages has been moved to `stderr` to allow output to be fetched like
```
$ echo "Version required by module: $(go run main.go --chdir ~/foo/ --show-latest-required)"
Reading required version from terraform file
Reading required version from constraint: ~> 1.4.0, < 1.4.5
Matched version: 1.4.4
Version required by module: 1.4.4
```