### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Installation for other linux operation systems.
 ```sh
 curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
 ```
-By default installer script will try to download tfswitch binary into /usr/local/bin
+By default installer script will try to download `tfswitch` binary into `/usr/local/bin`  
 To install at custom path use below:
 ```sh
 curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b  $HOME/.local/bin latest

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Installation for other linux operation systems.
 ```sh
 curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
 ```
-
+By default installer script will try to download tfswitch binary into /usr/local/bin
+To install at custom path use below:
+```sh
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b  $HOME/.local/bin latest
+```
 ### Arch User Repository (AUR) packages for Arch Linux
 
 ```sh


### PR DESCRIPTION
Add information on how to use installer and install at PATH other than `/usr/local/bin` to avoid requiring root permissions for install.sh

Related to : https://github.com/warrensbox/terraform-switcher/issues/279