### PR TITLE
Feature: Add flag for install location (optional) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ tfswitch -c terraform_dir
 To install from a remote mirror other than the default(https://releases.hashicorp.com/terraform). Use the `-m` or `--mirror` parameter.    
 Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp`
 
+### Install to non-default location
+
+By default `tfswitch` will download the Terraform binary to the user home directory under this path: `/Users/warrenveerasingam/.terraform.versions`
+
+If you want to install the binaries outside of the home directory then you can provide the `-i` or `--install` to install Terraform binaries to a non-standard path. Useful if you want to install versions of Terraform that can be shared with multiple users.
+
+The Terraform binaries will then be placed in the folder `.terraform.versions` under the custom install path e.g. `/opt/terraform/.terraform.versions`
+
+```bash
+tfswitch -i /opt/terraform/
+```
+
+**NOTE**
+
+* The folder must exists before you run `tfswitch`
+* The folder passed in `-i`/`--install` must be created before running `tfswtich`
+
 ### Set a default TF version for CICD pipeline
 1. When using a CICD pipeline, you may want a default or fallback version to avoid the pipeline from hanging.
 2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` when no other versions could be detected.

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -68,7 +68,6 @@ func CheckSymlink(symlinkPath string) bool {
 // ChangeSymlink : move symlink to existing binary
 func ChangeSymlink(binVersionPath string, binPath string) {
 
-	//installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 	binPath = InstallableBinLocation(binPath)
 
 	/* remove current symlink if exist*/

--- a/main.go
+++ b/main.go
@@ -110,14 +110,14 @@ func main() {
 		/* latest pre-release implicit version. Ex: tfswitch --latest-pre 0.13 downloads 0.13.0-rc1 (latest) */
 		case *latestPre != "":
 			preRelease := true
-			installLatestImplicitVersion(*latestPre, custBinPath, mirrorURL, preRelease)
+			installLatestImplicitVersion(*latestPre, &binPath, mirrorURL, preRelease)
 		/* latest implicit version. Ex: tfswitch --latest 0.13 downloads 0.13.5 (latest) */
 		case *latestStable != "":
 			preRelease := false
-			installLatestImplicitVersion(*latestStable, custBinPath, mirrorURL, preRelease)
+			installLatestImplicitVersion(*latestStable, &binPath, mirrorURL, preRelease)
 		/* latest stable version */
 		case *latestFlag:
-			installLatestVersion(custBinPath, mirrorURL)
+			installLatestVersion(&binPath, mirrorURL)
 		/* version provided on command line as arg */
 		case len(args) == 1:
 			installVersion(args[0], &binPath, mirrorURL)
@@ -138,7 +138,7 @@ func main() {
 		case checkTFEnvExist() && len(args) == 0 && version == "":
 			tfversion := os.Getenv("TF_VERSION")
 			fmt.Printf("Terraform version environment variable: %s\n", tfversion)
-			installVersion(tfversion, custBinPath, mirrorURL)
+			installVersion(tfversion, &binPath, mirrorURL)
 		/* if terragrunt.hcl file found (IN ADDITION TO A TOML FILE) */
 		case fileExists(TGHACLFile) && checkVersionDefinedHCL(&TGHACLFile) && len(args) == 0:
 			installTGHclFile(&TGHACLFile, &binPath, mirrorURL)
@@ -309,7 +309,7 @@ func installVersion(arg string, custBinPath *string, mirrorURL *string) {
 	}
 }
 
-//retrive file content of regular file
+// retrive file content of regular file
 func retrieveFileContents(file string) string {
 	fileContents, err := ioutil.ReadFile(file)
 	if err != nil {


### PR DESCRIPTION
This change adds a new flag `-i` or `--install` that will allow you to set where the Terraform binary is downloaded/installed into. Useful for edge cases where you need to share commonly installed versions of Terraform. 

This is in draft as it is built upon this PRs that should be merged first. To save headaches with merge conflicts this PR already includes that commit.

- #295 

Thanks @jukie for the PR. 

Once the above PR has been merged ping me and I can update this branch with latest master.