### PR TITLE
Add -e flag to force semver lookup at releases.hashicorp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ tfswitch -c terraform_dir
 To install from a remote mirror other than the default(https://releases.hashicorp.com/terraform). Use the `-m` or `--mirror` parameter.    
 Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp`
 
+### Custom mirror and version lookup
+If the mirror is not fully in sync with hashicorp (for example when only caching downloaded files), use the `-e` or `--sem-ver-url` parameter to instruct tfswitch to use https://releases.hashicorp.com/terraform to determine the versions available. This is useful if you are using terraform version contraints.
+Ex: `tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp --sem-ver-url`
+
 ### Set a default TF version for CICD pipeline
 1. When using a CICD pipeline, you may want a default or fallback version to avoid the pipeline from hanging.
 2. Ex: `tfswitch -d 1.2.3` or `tfswitch --default 1.2.3` installs version `1.2.3` when no other versions could be detected.

--- a/lib/install.go
+++ b/lib/install.go
@@ -75,8 +75,8 @@ func GetInstallLocation() string {
 
 }
 
-//Install : Install the provided version in the argument
-func Install(tfversion string, binPath string, mirrorURL string) {
+// Install : Install the provided version in the argument
+func Install(tfversion, binPath, mirrorURL string) {
 
 	// if !ValidVersionFormat(tfversion) {
 	// 	fmt.Printf("The provided terraform version format does not exist - %s. Try `tfswitch -l` to see all available versions.\n", tfversion)
@@ -252,7 +252,7 @@ func GetRecentVersions() ([]string, error) {
 	return nil, nil
 }
 
-//CreateRecentFile : create a recent file
+// CreateRecentFile : create a recent file
 func CreateRecentFile(requestedVersion string) {
 
 	installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
@@ -260,7 +260,7 @@ func CreateRecentFile(requestedVersion string) {
 	WriteLines([]string{requestedVersion}, filepath.Join(installLocation, recentFile))
 }
 
-//ConvertExecutableExt : convert excutable with local OS extension
+// ConvertExecutableExt : convert excutable with local OS extension
 func ConvertExecutableExt(fpath string) string {
 	switch runtime.GOOS {
 	case "windows":
@@ -273,8 +273,8 @@ func ConvertExecutableExt(fpath string) string {
 	}
 }
 
-//InstallableBinLocation : Checks if terraform is installable in the location provided by the user.
-//If not, create $HOME/bin. Ask users to add  $HOME/bin to $PATH and return $HOME/bin as install location
+// InstallableBinLocation : Checks if terraform is installable in the location provided by the user.
+// If not, create $HOME/bin. Ask users to add  $HOME/bin to $PATH and return $HOME/bin as install location
 func InstallableBinLocation(userBinPath string) string {
 
 	usr, errCurr := user.Current()

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -15,7 +15,7 @@ type tfVersionList struct {
 	tflist []string
 }
 
-//GetTFList :  Get the list of available terraform version given the hashicorp url
+// GetTFList :  Get the list of available terraform version given the hashicorp url
 func GetTFList(mirrorURL string, preRelease bool) ([]string, error) {
 
 	result, error := GetTFURLBody(mirrorURL)
@@ -50,7 +50,7 @@ func GetTFList(mirrorURL string, preRelease bool) ([]string, error) {
 
 }
 
-//GetTFLatest :  Get the latest terraform version given the hashicorp url
+// GetTFLatest :  Get the latest terraform version given the hashicorp url
 func GetTFLatest(mirrorURL string) (string, error) {
 
 	result, error := GetTFURLBody(mirrorURL)
@@ -71,7 +71,7 @@ func GetTFLatest(mirrorURL string) (string, error) {
 	return "", nil
 }
 
-//GetTFLatestImplicit :  Get the latest implicit terraform version given the hashicorp url
+// GetTFLatestImplicit :  Get the latest implicit terraform version given the hashicorp url
 func GetTFLatestImplicit(mirrorURL string, preRelease bool, version string) (string, error) {
 	if preRelease == true {
 		//TODO: use GetTFList() instead of GetTFURLBody
@@ -105,7 +105,7 @@ func GetTFLatestImplicit(mirrorURL string, preRelease bool, version string) (str
 	return "", nil
 }
 
-//GetTFURLBody : Get list of terraform versions from hashicorp releases
+// GetTFURLBody : Get list of terraform versions from hashicorp releases
 func GetTFURLBody(mirrorURL string) ([]string, error) {
 
 	hasSlash := strings.HasSuffix(mirrorURL, "/")
@@ -138,7 +138,7 @@ func GetTFURLBody(mirrorURL string) ([]string, error) {
 	return result, nil
 }
 
-//VersionExist : check if requested version exist
+// VersionExist : check if requested version exist
 func VersionExist(val interface{}, array interface{}) (exists bool) {
 
 	exists = false
@@ -157,7 +157,7 @@ func VersionExist(val interface{}, array interface{}) (exists bool) {
 	return exists
 }
 
-//RemoveDuplicateVersions : remove duplicate version
+// RemoveDuplicateVersions : remove duplicate version
 func RemoveDuplicateVersions(elements []string) []string {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]bool{}


### PR DESCRIPTION
When using artifactory as a mirror, semvers are unable to be looked up when using a version constraint due to the way that artifactory will cache a terraform file version after its been downloaded.  The semver lookup needs to have a range of versions present already. Adds new -e flag to force this lookup at releases.hashicorp.com/terraform when -m (mirrorURL) flag is specified

Workaround for https://github.com/warrensbox/terraform-switcher/issues/311

Some autoformatting of the comments that can be removed if desired