### PR TITLE
Update the go version to 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.22
 
     working_directory: /home/circleci/go/src/github.com/warrensbox/terraform-switcher
 
@@ -34,7 +34,7 @@ jobs:
 
   release:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.22
 
     working_directory: /home/circleci/go/src/github.com/warrensbox/terraform-switcher
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/warrensbox/terraform-switcher
 
-go 1.18
+go 1.22
 
 require (
 	github.com/hashicorp/go-version v1.6.0


### PR DESCRIPTION
Updated the go version to 1.22 (latest) to fix the critical vulnerabilities 