### PR TITLE
Fix/refactor deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     run: |
       echo "Semantic Version: ${{ github.event.inputs.name }}"
       VERSION=${{ github.event.inputs.name }}
-      if [ "$VERSION" != "major" ] || [ "$VERSION" != "minor" ] || [ "$VERSION" != "patch" ]; then
+      if [ "$VERSION" != "major" ] && [ "$VERSION" != "minor" ] && [ "$VERSION" != "patch" ]; then
           echo "Error: Provided input string must be 'major', 'minor', or 'patch'"
           exit 1
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,11 @@
-# Trigger when MR to `release` is closed
-
-name: Build-Test-Release Code
+name: Release (Manual Step)
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - release
-
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Enter - major, minor, patch"
+        default: "patch"
 
 jobs:
   tfswitch-release:
@@ -16,10 +13,19 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
+    - name: Check if provided input is valid
+    run: |
+      echo "Semantic Version: ${{ github.event.inputs.name }}"
+      VERSION=${{ github.event.inputs.name }}
+      if [ "$VERSION" != "major" ] || [ "$VERSION" != "minor" ] || [ "$VERSION" != "patch" ]; then
+          echo "Error: Provided input string must be 'major', 'minor', or 'patch'"
+          exit 1
+        fi
+
     # Checkout code from repo
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.ref_name }} # required for better experience using pre-releases
+        ref: ${{ github.head_ref }} # required for better experience using pre-releases
         #fetch-depth: '0'
 
     # Install go
@@ -42,10 +48,40 @@ jobs:
       run: mkdir -p build && go build -v -o build/tfswitch && build/tfswitch --help
       continue-on-error: false
 
+    - name: Create dry tag 
+      uses: anothrNick/github-tag-action@1.67.0
+      id: semver-tag-dry 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: false
+        INITIAL_VERSION: 1.0.0
+        RELEASE_BRANCHES: master
+        DEFAULT_BUMP: ${{ github.event.inputs.name }}
+        PRERELEASE: false
+        DRY_RUN: true #only get the tag
+        VERBOSE: true
+
+    # Write new version into version file    
+    - name: Write new version tag to version file
+      run: |
+        echo ${{ steps.semver-tag-dry.outputs.tag }} > version
+
+    - name: Commit version into repo
+      run: |
+        git config --global user.email "release-bot@users.noreply.github.com"
+        git config --global user.name "release-bot"
+        git commit -a -m "#{{ github.event.inputs.name }} - Setting semantic version"
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
+
     # Introduce new tag
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.67.0
-      id: tagging  
+      id: semver-tag  
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: false
@@ -66,7 +102,7 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_VERSION: ${{ steps.tagging.outputs.tag }}
+        RELEASE_VERSION: ${{ steps.semver-tag.outputs.tag }}
         PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
     - name: Install Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }} # required for better experience using pre-releases
-        #fetch-depth: '0'
+        fetch-depth: '0'
 
     # Install go
     - name: Checkout go
@@ -58,7 +58,7 @@ jobs:
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: ${{ github.event.inputs.name }}
         PRERELEASE: false
-        DRY_RUN: true #only get the tag
+        DRY_RUN: true #only get the tag - dry
         VERBOSE: true
 
     # Write new version into version file    
@@ -66,19 +66,21 @@ jobs:
       run: |
         echo ${{ steps.semver-tag-dry.outputs.tag }} > version
 
+    # Commit the changes in the previous step
     - name: Commit version into repo
       run: |
         git config --global user.email "release-bot@users.noreply.github.com"
         git config --global user.name "release-bot"
         git commit -a -m "#{{ github.event.inputs.name }} - Setting semantic version"
 
+    # Push the changes to remote
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.ref }}
 
-    # Introduce new tag
+    # Introduce new tag (for real)
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.67.0
       id: semver-tag  
@@ -86,13 +88,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: false
         INITIAL_VERSION: 1.0.0
-        RELEASE_BRANCHES: release
-        DEFAULT_BUMP: patch
+        RELEASE_BRANCHES: master
+        DEFAULT_BUMP: ${{ github.event.inputs.name }}
         PRERELEASE: false
-        DRY_RUN: false
+        DRY_RUN: false #not dry
         VERBOSE: true
-        BRANCH_HISTORY: last
-        TAG_CONTEXT: branch
 
     # Run goreleaser to create new binaries
     - name: Run GoReleaser


### PR DESCRIPTION
Planning to remove the "release" branch. 
- With the new setup, we do not have to merge to "release" to deploy the new code.
- We can constantly push to master and release it bi weekly
-  This will make iteration faster
- It has alway been a hassle managing the release banch

https://github.com/warrensbox/terraform-switcher/assets/38867521/b2e5d694-49f9-4a86-a31a-c48cdb525465


