### PR TITLE
feat: Build statically linked binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Run test
+name: Run tests
 
 on:
   push:
@@ -6,19 +6,24 @@ on:
       - '*'         # matches every branch that doesn't contain a '/'
       - '*/*'       # matches every branch containing a single '/'
       - '**'        # matches every branch
-      - '!release'   # excludes master
-jobs:
+      - '!release'  # excludes `release` branch
 
+env:
+  CGO_ENABLED: 0 # Build statically linked binaries
+
+jobs:
   integration_tests_linux:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         go_version: ['1.22']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
 
-    - name: Set up Go
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go_version }}
@@ -46,9 +51,11 @@ jobs:
         go_version: ['1.22']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
 
-    - name: Set up Go
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Run tests
 on:
   push:
     branches: 
-      - '*'         # matches every branch that doesn't contain a '/'
-      - '*/*'       # matches every branch containing a single '/'
-      - '**'        # matches every branch
-      - '!release'  # excludes `release` branch
+      - '*'       # matches every branch that doesn't contain a '/'
+      - '*/*'     # matches every branch containing a single '/'
+      - '**'      # matches every branch
+      - '!master' # excludes `master` branch
 
 env:
   CGO_ENABLED: 0 # Build statically linked binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tfswitch-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Check if provided input is valid
@@ -28,23 +28,25 @@ jobs:
         ref: ${{ github.head_ref }} # required for better experience using pre-releases
         fetch-depth: '0'
 
-    # Install go
-    - name: Checkout go
+    # Install Go
+    - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22' # The Go version to download (if necessary) and use.
+        go-version: '1.22' # The Go version to download (if necessary) and use
   
-    # Double check go version
+    # Double check Go version
     - name: Go version
       id: Version
       run: go version
 
-    # Download dependencies
+    # Download Go dependencies
     - name: Go download
       run: go mod download
 
     # Test to see if tfswitch works with --help
     - name: Go build
+      env:
+        CGO_ENABLED: 0 # Build statically linked binaries
       run: mkdir -p build && go build -v -o build/tfswitch && build/tfswitch --help
       continue-on-error: false
 
@@ -58,7 +60,7 @@ jobs:
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: ${{ github.event.inputs.name }}
         PRERELEASE: false
-        DRY_RUN: true #only get the tag - dry
+        DRY_RUN: true # Only get the tag - dry
         VERBOSE: true
 
     # Write new version into version file    
@@ -91,7 +93,7 @@ jobs:
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: ${{ github.event.inputs.name }}
         PRERELEASE: false
-        DRY_RUN: false #not dry
+        DRY_RUN: false # Not dry
         VERBOSE: true
 
     # Run goreleaser to create new binaries
@@ -105,19 +107,20 @@ jobs:
         RELEASE_VERSION: ${{ steps.semver-tag.outputs.tag }}
         PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
+    # Install Python
     - name: Install Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
 
+    # Install Py dependencies
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install mkdocs-material
 
+    # Build WWW page
     - name: Build page   
       run: cd www && mkdocs gh-deploy --force
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+# https://goreleaser.com/
+env:
+  - CGO_ENABLED=0 # Build statically linked binaries
 builds:
   -
     ldflags:
@@ -36,11 +37,8 @@ archives:
       {{- .ProjectName }}_
       {{- .Env.RELEASE_VERSION }}_
       {{- .Os }}_
-      {{- if eq .Arch "amd64" }}amd64
-      {{- else if eq .Arch "386" }}386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
-
 
 brews:
   -
@@ -48,7 +46,7 @@ brews:
     # Default to project name
     name: tfswitch
 
-  # GitHub/GitLab repository to push the formula to
+    # GitHub/GitLab repository to push the formula to
     # Gitea is not supported yet, but the support coming
     repository:
       owner: warrensbox


### PR DESCRIPTION
- Switch back to `ubuntu-latest` GH runners but build statically linked Go binaries instead
  - Confirmed Linux `amd64` binary works on Linux Mint 19.3 Tricia (based on Ubuntu Bionic 18.04)
  - No penalty on the size of binaries as of look of it
- While here, brush up and align GH Workflow YAML configs a bit