### PR TITLE
bugfix: Fix Fatal logger calls by force exit

### DIFF
--- a/lib/defaults.go
+++ b/lib/defaults.go
@@ -1,8 +1,10 @@
 package lib
 
 import (
-	"github.com/mitchellh/go-homedir"
+	"os"
 	"runtime"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // GetDefaultBin Get default binary path
@@ -12,6 +14,7 @@ func GetDefaultBin() string {
 		home, err := homedir.Dir()
 		if err != nil {
 			logger.Fatal("Could not detect home directory.")
+			os.Exit(1)
 		}
 		defaultBin = home + "/bin/terraform.exe"
 	}

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -23,7 +23,6 @@ func TestDownloadFromURL_FileNameMatch(t *testing.T) {
 	home, err := homedir.Dir()
 	if err != nil {
 		logger.Fatalf("Could not detect home directory")
-		os.Exit(1)
 	}
 
 	logger.Infof("Current home directory: %q", home)

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -2,12 +2,13 @@ package lib
 
 import (
 	"fmt"
-	"github.com/mitchellh/go-homedir"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // TestDownloadFromURL_FileNameMatch : Check expected filename exist when downloaded
@@ -22,6 +23,7 @@ func TestDownloadFromURL_FileNameMatch(t *testing.T) {
 	home, err := homedir.Dir()
 	if err != nil {
 		logger.Fatalf("Could not detect home directory")
+		os.Exit(1)
 	}
 
 	logger.Infof("Current home directory: %q", home)

--- a/lib/files.go
+++ b/lib/files.go
@@ -170,6 +170,7 @@ func IsDirEmpty(name string) bool {
 	f, err := os.Open(name)
 	if err != nil {
 		logger.Fatal(err)
+		os.Exit(1)
 	}
 	defer f.Close()
 
@@ -188,6 +189,7 @@ func CheckDirHasTGBin(dir, prefix string) bool {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		logger.Fatal(err)
+		os.Exit(1)
 	}
 	res := []string{}
 	for _, f := range files {

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -26,6 +26,7 @@ func TestRenameFile(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -72,6 +73,7 @@ func TestRemoveFiles(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -111,6 +113,7 @@ func TestUnzip(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -120,6 +123,7 @@ func TestUnzip(t *testing.T) {
 
 	if errUnzip != nil {
 		logger.Fatalf("Unable to unzip %q file: %v", absPath, errUnzip)
+		os.Exit(1)
 	}
 
 	tst := strings.Join(files, "")
@@ -141,6 +145,7 @@ func TestCreateDirIfNotExist(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -176,6 +181,7 @@ func TestWriteLines(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -189,6 +195,7 @@ func TestWriteLines(t *testing.T) {
 	if errWrite != nil {
 		t.Logf("Write should work %v (unexpected)", errWrite)
 		logger.Fatal(errWrite)
+		os.Exit(1)
 	} else {
 		var (
 			file             *os.File
@@ -199,6 +206,7 @@ func TestWriteLines(t *testing.T) {
 		)
 		if file, errOpen = os.Open(recentFilePath); errOpen != nil {
 			logger.Fatal(errOpen)
+			os.Exit(1)
 		}
 
 		reader := bufio.NewReader(file)
@@ -219,12 +227,13 @@ func TestWriteLines(t *testing.T) {
 
 		if errRead != nil {
 			logger.Fatalf("Error: %s", errRead)
+			os.Exit(1)
 		}
 
 		for _, line := range lines {
 			if !semverRegex.MatchString(line) {
 				logger.Fatalf("Write to file is not invalid: %s", line)
-				break
+				os.Exit(1)
 			}
 		}
 
@@ -244,6 +253,7 @@ func TestReadLines(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -259,13 +269,14 @@ func TestReadLines(t *testing.T) {
 
 	if file, errCreate = os.Create(recentFilePath); errCreate != nil {
 		logger.Fatalf("Error: %s", errCreate)
+		os.Exit(1)
 	}
 
 	for _, item := range test_array {
 		_, err := file.WriteString(strings.TrimSpace(item) + "\n")
 		if err != nil {
 			logger.Fatalf("Error: %s", err)
-			break
+			os.Exit(1)
 		}
 	}
 
@@ -273,12 +284,13 @@ func TestReadLines(t *testing.T) {
 
 	if errRead != nil {
 		logger.Fatalf("Error: %s", errRead)
+		os.Exit(1)
 	}
 
 	for _, line := range lines {
 		if !semverRegex.MatchString(line) {
 			logger.Fatalf("Write to file is not invalid: %s", line)
-			break
+			os.Exit(1)
 		}
 	}
 
@@ -297,6 +309,7 @@ func TestIsDirEmpty(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -332,6 +345,7 @@ func TestCheckDirHasTFBin(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -361,6 +375,7 @@ func TestPath(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -402,6 +417,7 @@ func TestConvertExecutableExt(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 
 	installPath := "/.terraform.versions_test/"

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -26,7 +26,6 @@ func TestRenameFile(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -73,7 +72,6 @@ func TestRemoveFiles(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -113,7 +111,6 @@ func TestUnzip(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -123,7 +120,6 @@ func TestUnzip(t *testing.T) {
 
 	if errUnzip != nil {
 		logger.Fatalf("Unable to unzip %q file: %v", absPath, errUnzip)
-		os.Exit(1)
 	}
 
 	tst := strings.Join(files, "")
@@ -145,7 +141,6 @@ func TestCreateDirIfNotExist(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -181,7 +176,6 @@ func TestWriteLines(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -195,7 +189,6 @@ func TestWriteLines(t *testing.T) {
 	if errWrite != nil {
 		t.Logf("Write should work %v (unexpected)", errWrite)
 		logger.Fatal(errWrite)
-		os.Exit(1)
 	} else {
 		var (
 			file             *os.File
@@ -206,7 +199,6 @@ func TestWriteLines(t *testing.T) {
 		)
 		if file, errOpen = os.Open(recentFilePath); errOpen != nil {
 			logger.Fatal(errOpen)
-			os.Exit(1)
 		}
 
 		reader := bufio.NewReader(file)
@@ -227,13 +219,12 @@ func TestWriteLines(t *testing.T) {
 
 		if errRead != nil {
 			logger.Fatalf("Error: %s", errRead)
-			os.Exit(1)
 		}
 
 		for _, line := range lines {
 			if !semverRegex.MatchString(line) {
 				logger.Fatalf("Write to file is not invalid: %s", line)
-				os.Exit(1)
+				break
 			}
 		}
 
@@ -253,7 +244,6 @@ func TestReadLines(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -269,14 +259,13 @@ func TestReadLines(t *testing.T) {
 
 	if file, errCreate = os.Create(recentFilePath); errCreate != nil {
 		logger.Fatalf("Error: %s", errCreate)
-		os.Exit(1)
 	}
 
 	for _, item := range test_array {
 		_, err := file.WriteString(strings.TrimSpace(item) + "\n")
 		if err != nil {
 			logger.Fatalf("Error: %s", err)
-			os.Exit(1)
+			break
 		}
 	}
 
@@ -284,13 +273,11 @@ func TestReadLines(t *testing.T) {
 
 	if errRead != nil {
 		logger.Fatalf("Error: %s", errRead)
-		os.Exit(1)
 	}
 
 	for _, line := range lines {
 		if !semverRegex.MatchString(line) {
 			logger.Fatalf("Write to file is not invalid: %s", line)
-			os.Exit(1)
 		}
 	}
 
@@ -309,7 +296,6 @@ func TestIsDirEmpty(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -345,7 +331,6 @@ func TestCheckDirHasTFBin(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -375,7 +360,6 @@ func TestPath(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	installLocation := filepath.Join(homedir, installPath)
 
@@ -417,7 +401,6 @@ func TestConvertExecutableExt(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 
 	installPath := "/.terraform.versions_test/"

--- a/lib/install.go
+++ b/lib/install.go
@@ -301,4 +301,5 @@ func InstallableBinLocation(userBinPath string) string {
 
 	logger.Fatalf("Binary path (%q) does not exist. Manually create bin directory %q and try again.", userBinPath, binDir)
 	os.Exit(1)
+	return ""
 }

--- a/lib/install.go
+++ b/lib/install.go
@@ -54,6 +54,7 @@ func GetInstallLocation() string {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 
 	userCommon := homedir
@@ -125,12 +126,14 @@ func Install(tfversion string, binPath string, mirrorURL string) {
 	/* If unable to download file from url, exit(1) immediately */
 	if errDownload != nil {
 		logger.Fatalf("Error downloading %s: %v", url, errDownload)
+		os.Exit(1)
 	}
 
 	/* unzip the downloaded zipfile */
 	_, errUnzip := Unzip(zipFile, installLocation)
 	if errUnzip != nil {
 		logger.Fatalf("Unable to unzip %q file: %v", zipFile, errUnzip)
+		os.Exit(1)
 	}
 
 	/* rename unzipped file to terraform version name - terraform_x.x.x */
@@ -264,6 +267,7 @@ func InstallableBinLocation(userBinPath string) string {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 
 	binDir := Path(userBinPath)           //get path directory from binary path
@@ -294,7 +298,7 @@ func InstallableBinLocation(userBinPath string) string {
 			return filepath.Join(userBinPath)
 		}
 	}
+
 	logger.Fatalf("Binary path (%q) does not exist. Manually create bin directory %q and try again.", userBinPath, binDir)
 	os.Exit(1)
-	return ""
 }

--- a/lib/list_versions_test.go
+++ b/lib/list_versions_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
@@ -32,7 +31,6 @@ func TestGetTFList(t *testing.T) {
 
 	if !exists {
 		logger.Fatalf("Not able to find version: %s", val)
-		os.Exit(1)
 	} else {
 		t.Log("Write versions exist (expected)")
 	}
@@ -48,7 +46,6 @@ func TestRemoveDuplicateVersions(t *testing.T) {
 
 	if len(list) == len(test_array) {
 		logger.Fatalf("Not able to remove duplicate: %s\n", test_array)
-		os.Exit(1)
 	} else {
 		t.Log("Write versions exist (expected)")
 	}
@@ -67,7 +64,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "1.11.9"
@@ -78,7 +74,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "1.11.a"
@@ -89,7 +84,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "22323"
@@ -100,7 +94,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "@^&*!)!"
@@ -111,7 +104,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "1.11.9-beta1"
@@ -122,7 +114,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "0.12.0-rc2"
@@ -133,7 +124,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "1.11.4-boom"
@@ -144,7 +134,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 	version = "1.11.4-1"
@@ -155,7 +144,6 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
-		os.Exit(1)
 	}
 
 }

--- a/lib/list_versions_test.go
+++ b/lib/list_versions_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -31,6 +32,7 @@ func TestGetTFList(t *testing.T) {
 
 	if !exists {
 		logger.Fatalf("Not able to find version: %s", val)
+		os.Exit(1)
 	} else {
 		t.Log("Write versions exist (expected)")
 	}
@@ -46,6 +48,7 @@ func TestRemoveDuplicateVersions(t *testing.T) {
 
 	if len(list) == len(test_array) {
 		logger.Fatalf("Not able to remove duplicate: %s\n", test_array)
+		os.Exit(1)
 	} else {
 		t.Log("Write versions exist (expected)")
 	}
@@ -64,6 +67,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "1.11.9"
@@ -74,6 +78,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "1.11.a"
@@ -84,6 +89,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "22323"
@@ -94,6 +100,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "@^&*!)!"
@@ -104,6 +111,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "1.11.9-beta1"
@@ -114,6 +122,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "0.12.0-rc2"
@@ -124,6 +133,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "1.11.4-boom"
@@ -134,6 +144,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Valid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 	version = "1.11.4-1"
@@ -144,6 +155,7 @@ func TestValidVersionFormat(t *testing.T) {
 		t.Logf("Invalid version format : %s (expected)", version)
 	} else {
 		logger.Fatalf("Failed to verify version format: %s\n", version)
+		os.Exit(1)
 	}
 
 }

--- a/lib/symlink_test.go
+++ b/lib/symlink_test.go
@@ -1,11 +1,12 @@
 package lib
 
 import (
-	"github.com/mitchellh/go-homedir"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // TestCreateSymlink : check if symlink exist-remove if exist,
@@ -21,6 +22,7 @@ func TestCreateSymlink(t *testing.T) {
 	home, err := homedir.Dir()
 	if err != nil {
 		logger.Fatalf("Could not detect home directory.")
+		os.Exit(1)
 	}
 	symlinkPathSrc := filepath.Join(home, testSymlinkSrc)
 	symlinkPathDest := filepath.Join(home, testSymlinkDest)
@@ -29,6 +31,7 @@ func TestCreateSymlink(t *testing.T) {
 	create, err := os.Create(symlinkPathDest)
 	if err != nil {
 		logger.Fatalf("Could not create test dest file for symlink at %v", symlinkPathDest)
+		os.Exit(1)
 	}
 	defer create.Close()
 
@@ -79,6 +82,7 @@ func TestRemoveSymlink(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	symlinkPathSrc := filepath.Join(homedir, testSymlinkSrc)
 	symlinkPathDest := filepath.Join(homedir, testSymlinkDest)
@@ -114,6 +118,7 @@ func TestCheckSymlink(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
+		os.Exit(1)
 	}
 	symlinkPathSrc := filepath.Join(homedir, testSymlinkSrc)
 	symlinkPathDest := filepath.Join(homedir, testSymlinkDest)

--- a/lib/symlink_test.go
+++ b/lib/symlink_test.go
@@ -22,7 +22,6 @@ func TestCreateSymlink(t *testing.T) {
 	home, err := homedir.Dir()
 	if err != nil {
 		logger.Fatalf("Could not detect home directory.")
-		os.Exit(1)
 	}
 	symlinkPathSrc := filepath.Join(home, testSymlinkSrc)
 	symlinkPathDest := filepath.Join(home, testSymlinkDest)
@@ -31,7 +30,6 @@ func TestCreateSymlink(t *testing.T) {
 	create, err := os.Create(symlinkPathDest)
 	if err != nil {
 		logger.Fatalf("Could not create test dest file for symlink at %v", symlinkPathDest)
-		os.Exit(1)
 	}
 	defer create.Close()
 
@@ -82,7 +80,6 @@ func TestRemoveSymlink(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	symlinkPathSrc := filepath.Join(homedir, testSymlinkSrc)
 	symlinkPathDest := filepath.Join(homedir, testSymlinkDest)
@@ -118,7 +115,6 @@ func TestCheckSymlink(t *testing.T) {
 	homedir, errCurr := homedir.Dir()
 	if errCurr != nil {
 		logger.Fatal(errCurr)
-		os.Exit(1)
 	}
 	symlinkPathSrc := filepath.Join(homedir, testSymlinkSrc)
 	symlinkPathDest := filepath.Join(homedir, testSymlinkDest)

--- a/main.go
+++ b/main.go
@@ -270,6 +270,7 @@ func showLatestImplicitVersion(requestedVersion string, custBinPath, mirrorURL *
 			logger.Infof("%s", tfversion)
 		} else {
 			logger.Fatal("The provided terraform version does not exist.\n Try `tfswitch -l` to see all available versions")
+			os.Exit(1)
 		}
 	} else {
 		lib.PrintInvalidMinorTFVersion()
@@ -301,6 +302,7 @@ func installVersion(arg string, custBinPath *string, mirrorURL *string) {
 			lib.Install(requestedVersion, *custBinPath, *mirrorURL)
 		} else {
 			logger.Fatal("The provided terraform version does not exist.\n Try `tfswitch -l` to see all available versions")
+			os.Exit(1)
 		}
 
 	} else {
@@ -316,6 +318,7 @@ func retrieveFileContents(file string) string {
 	fileContents, err := ioutil.ReadFile(file)
 	if err != nil {
 		logger.Fatalf("Failed reading %q file: %v\n Follow the README.md instructions for setup: https://github.com/warrensbox/terraform-switcher/blob/master/README.md", tfvFilename, err)
+		os.Exit(1)
 	}
 	tfversion := strings.TrimSuffix(string(fileContents), "\n")
 	return tfversion
@@ -361,6 +364,7 @@ func getParamsTOML(binPath string, dir string) (string, string) {
 
 	if err != nil {
 		logger.Fatalf("Unable to get home directory: %v", err)
+		os.Exit(1)
 	}
 
 	if dir == path {
@@ -377,6 +381,7 @@ func getParamsTOML(binPath string, dir string) (string, string) {
 	errs := viper.ReadInConfig() // Find and read the config file
 	if errs != nil {
 		logger.Fatalf("Failed to read %q: %v", tomlFilename, errs)
+		os.Exit(1)
 	}
 
 	bin := viper.Get("bin")                                                     // read custom binary location
@@ -408,9 +413,10 @@ func installOption(listAll bool, custBinPath, mirrorURL *string) {
 	tflist = lib.RemoveDuplicateVersions(tflist)    //remove duplicate version
 
 	if len(tflist) == 0 {
-
 		logger.Fatalf("Terraform version list is empty: %s", *mirrorURL)
+		os.Exit(1)
 	}
+
 	/* prompt user to select version of terraform */
 	prompt := promptui.Select{
 		Label: "Select Terraform version",
@@ -422,6 +428,7 @@ func installOption(listAll bool, custBinPath, mirrorURL *string) {
 
 	if errPrompt != nil {
 		logger.Fatalf("Prompt failed %v", errPrompt)
+		os.Exit(1)
 	}
 
 	lib.Install(tfversion, *custBinPath, *mirrorURL)
@@ -444,6 +451,7 @@ func installFromConstraint(tfconstraint *string, custBinPath, mirrorURL *string)
 		lib.Install(tfversion, *custBinPath, *mirrorURL)
 	}
 	logger.Fatalf("No version found to match constraint: %v.\n Follow the README.md instructions for setup: https://github.com/warrensbox/terraform-switcher/blob/master/README.md", err)
+	os.Exit(1)
 }
 
 // Install using version constraint from terragrunt file
@@ -453,6 +461,7 @@ func installTGHclFile(tgFile *string, custBinPath, mirrorURL *string) {
 	file, diags := parser.ParseHCLFile(*tgFile) //use hcl parser to parse HCL file
 	if diags.HasErrors() {
 		logger.Fatalf("Unable to parse %q file", *tgFile)
+		os.Exit(1)
 	}
 	var version terragruntVersionConstraints
 	gohcl.DecodeBody(file.Body, nil, &version)
@@ -469,6 +478,7 @@ func checkVersionDefinedHCL(tgFile *string) bool {
 	file, diags := parser.ParseHCLFile(*tgFile) //use hcl parser to parse HCL file
 	if diags.HasErrors() {
 		logger.Fatalf("Unable to parse %q file", *tgFile)
+		os.Exit(1)
 	}
 	var version terragruntVersionConstraints
 	gohcl.DecodeBody(file.Body, nil, &version)


### PR DESCRIPTION
Attempt to hastily fix Fatal level calls to logger by appending `os.Exit(1)` to each `logger.Fatal()` (`logger.Fatalf()`) call, as it appeared that it doesn't exit as we'd expect it to.

Refs:
- #334 (comment)
- gookit/slog#143