### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,7 @@ updates:
     commit-message:
       prefix: "go:"
     labels:
-      - c:deps
-      - golang
+      - dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,15 @@ updates:
     commit-message:
       prefix: "go:"
     labels:
+      - golang
       - dependencies
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
       time: "07:00"
+    commit-message:
+      prefix: "gh-actions:"
+    labels:
+      - gh-actions
+      - dependencies


### PR DESCRIPTION
Update labels for dependabot as the labels don't exists in the default.
We do, however have a dependency label that could be used.
This is just mere convenience. Before that the bot tried to set non existing labels.