### PR TITLE
Fix for #400 - Whitespaces and Version Constraints

### DIFF
--- a/lib/param_parsing/versiontf.go
+++ b/lib/param_parsing/versiontf.go
@@ -12,7 +12,6 @@ import (
 
 func GetVersionFromVersionsTF(params Params) (Params, error) {
 	var tfConstraints []string
-	//var exactConstraints []string
 
 	curDir, err := os.Getwd()
 	if err != nil {

--- a/lib/param_parsing/versiontf.go
+++ b/lib/param_parsing/versiontf.go
@@ -4,7 +4,6 @@ import (
 	semver "github.com/hashicorp/go-version"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
@@ -66,10 +65,4 @@ func GetVersionFromVersionsTF(params Params) (Params, error) {
 func isTerraformModule(params Params) bool {
 	module, err := tfconfig.LoadModule(params.ChDirPath)
 	return err == nil && len(module.RequiredCore) > 0
-}
-
-func cleanupVersionConstraints(constraint string) string {
-	regex := regexp.MustCompile(`(?P<Comparator>\D+)(?P<Version>(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?)$`)
-	stringSubmatch := regex.FindStringSubmatch(constraint)
-	return strings.TrimSpace(stringSubmatch[1]) + " " + stringSubmatch[2]
 }

--- a/lib/param_parsing/versiontf_test.go
+++ b/lib/param_parsing/versiontf_test.go
@@ -17,7 +17,7 @@ func TestGetVersionFromVersionsTF_matches_version(t *testing.T) {
 	v1, _ := version.NewVersion("1.0.5")
 	actualVersion, _ := version.NewVersion(params.Version)
 	if !actualVersion.Equal(v1) {
-		t.Error("Determined version is not 1.0.5")
+		t.Errorf("Determined version is not 1.0.5, but %s", params.Version)
 	}
 }
 

--- a/lib/param_parsing/versiontf_test.go
+++ b/lib/param_parsing/versiontf_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/hashicorp/go-version"
 	"github.com/warrensbox/terraform-switcher/lib"
-	"strings"
 	"testing"
 )
 
@@ -21,19 +20,20 @@ func TestGetVersionFromVersionsTF_matches_version(t *testing.T) {
 	}
 }
 
-func TestGetVersionFromVersionsTF_non_matching_constraints(t *testing.T) {
+func TestGetVersionFromVersionsTF_impossible_constraints(t *testing.T) {
 	logger = lib.InitLogger("DEBUG")
 	var params Params
 	params = initParams(params)
 	params.ChDirPath = "../../test-data/skip-integration-tests/test_versiontf_non_matching_constraints"
 	params, err := GetVersionFromVersionsTF(params)
+	expectedError := "did not find version matching constraint: ~> 1.0.0, =1.0.5, <= 1.0.4"
 	if err == nil {
-		t.Error("Expected error but got nil")
+		t.Errorf("Expected error '%s', got nil", expectedError)
 	} else {
-		expected := "exact constraint ("
-		expected2 := ") cannot be combined with other conditions"
-		if !strings.Contains(fmt.Sprint(err), expected) || !strings.Contains(fmt.Sprint(err), expected2) {
-			t.Errorf("Expected error string containing %q and %q. Got %q", expected, expected2, err)
+		if err.Error() == expectedError {
+			t.Logf("Got expected error '%s'", err)
+		} else {
+			t.Errorf("Got unexpected error '%s'", err)
 		}
 	}
 }
@@ -47,7 +47,7 @@ func TestGetVersionFromVersionsTF_erroneous_file(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error got nil")
 	} else {
-		expected := "error parsing constraint: Malformed constraint: ~527> 1.0.0"
+		expected := "Malformed constraint: ~527> 1.0.0"
 		if fmt.Sprint(err) != expected {
 			t.Errorf("Expected error %q, got %q", expected, err)
 		}

--- a/test-data/integration-tests/test_versiontf/version.tf
+++ b/test-data/integration-tests/test_versiontf/version.tf
@@ -3,5 +3,5 @@ terraform {
 }
 
 terraform {
-  required_version = "<= 1.0.5"
+  required_version = "<=1.0.5"
 }

--- a/test-data/skip-integration-tests/test_versiontf_non_matching_constraints/version.tf
+++ b/test-data/skip-integration-tests/test_versiontf_non_matching_constraints/version.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 terraform {
-  required_version = "= 1.0.5"
+  required_version = "=1.0.5"
 }
 
 terraform {


### PR DESCRIPTION
- added fix for #400 when the comparator is not separated from the version number by a space
- possibly fixes #402 as well