### PR TITLE
Fix terragrunt parsing

### DIFF
--- a/lib/param_parsing/terragrunt.go
+++ b/lib/param_parsing/terragrunt.go
@@ -25,8 +25,8 @@ func GetVersionFromTerragrunt(params Params) (Params, error) {
 		}
 		var versionFromTerragrunt terragruntVersionConstraints
 		diagnostics = gohcl.DecodeBody(hclFile.Body, nil, &versionFromTerragrunt)
-		if diagnostics.HasErrors() {
-			return params, fmt.Errorf("could not decode body of HCL file %q", filePath)
+		if versionFromTerragrunt.TerraformVersionConstraint == "" {
+			return params, fmt.Errorf("could not find terraform_version_constraint in file %q", filePath)
 		}
 		version, err := lib.GetSemver(versionFromTerragrunt.TerraformVersionConstraint, params.MirrorURL)
 		if err != nil {

--- a/lib/param_parsing/terragrunt.go
+++ b/lib/param_parsing/terragrunt.go
@@ -26,7 +26,8 @@ func GetVersionFromTerragrunt(params Params) (Params, error) {
 		var versionFromTerragrunt terragruntVersionConstraints
 		diagnostics = gohcl.DecodeBody(hclFile.Body, nil, &versionFromTerragrunt)
 		if versionFromTerragrunt.TerraformVersionConstraint == "" {
-			return params, fmt.Errorf("could not find terraform_version_constraint in file %q", filePath)
+			logger.Infof("No terraform version constraint in %q", filePath)
+			return params, nil
 		}
 		version, err := lib.GetSemver(versionFromTerragrunt.TerraformVersionConstraint, params.MirrorURL)
 		if err != nil {

--- a/lib/param_parsing/terragrunt_test.go
+++ b/lib/param_parsing/terragrunt_test.go
@@ -9,9 +9,13 @@ import (
 
 func TestGetVersionFromTerragrunt(t *testing.T) {
 	var params Params
+	logger = lib.InitLogger("DEBUG")
 	params = initParams(params)
 	params.ChDirPath = "../../test-data/integration-tests/test_terragrunt_hcl"
-	params, _ = GetVersionFromTerragrunt(params)
+	params, err := GetVersionFromTerragrunt(params)
+	if err != nil {
+		t.Fatalf("Got error '%s'", err)
+	}
 	v1, _ := version.NewVersion("0.13")
 	v2, _ := version.NewVersion("0.14")
 	actualVersion, _ := version.NewVersion(params.Version)
@@ -40,7 +44,7 @@ func TestGetVersionFromTerragrunt_erroneous_file(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error but got none.")
 	} else {
-		expectedError := "could not decode body of HCL file"
+		expectedError := "could not find terraform_version_constraint in file"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Errorf("Expected error to contain '%q', got '%q'", expectedError, err)
 		}

--- a/lib/param_parsing/terragrunt_test.go
+++ b/lib/param_parsing/terragrunt_test.go
@@ -3,7 +3,6 @@ package param_parsing
 import (
 	"github.com/hashicorp/go-version"
 	"github.com/warrensbox/terraform-switcher/lib"
-	"strings"
 	"testing"
 )
 
@@ -41,12 +40,11 @@ func TestGetVersionFromTerragrunt_erroneous_file(t *testing.T) {
 	params = initParams(params)
 	params.ChDirPath = "../../test-data/skip-integration-tests/test_terragrunt_error_hcl"
 	params, err := GetVersionFromTerragrunt(params)
-	if err == nil {
-		t.Error("Expected error but got none.")
-	} else {
-		expectedError := "could not find terraform_version_constraint in file"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Errorf("Expected error to contain '%q', got '%q'", expectedError, err)
-		}
+	if err != nil {
+		t.Error(err)
+	}
+	expected := ""
+	if params.Version != expected {
+		t.Errorf("Expected version '%s', got '%s'", expected, params.Version)
 	}
 }

--- a/test-data/integration-tests/test_terragrunt_hcl/terragrunt.hcl
+++ b/test-data/integration-tests/test_terragrunt_hcl/terragrunt.hcl
@@ -1,1 +1,2 @@
+terragrunt_version_constraint = "= 0.36.2"
 terraform_version_constraint = ">= 0.13, < 0.14"


### PR DESCRIPTION
This will fix #401 

* removed diagnostic.hasError check as it is expected to have an error every time something is present that we are not looking explicitly for.
* introduced test if a terraform_version_constraint can be found in hcl file.