### PR TITLE
docs: Fix links to `install.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See the [release page](https://github.com/warrensbox/terraform-switcher/releases
 
 For macOS or various Linux distributions, Homebrew offers the simplest installation process. <a href="https://brew.sh/" target="_blank">If you do not have homebrew installed, click here</a>.
 
-```ruby
+```shell
 brew install warrensbox/tap/tfswitch
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ brew install warrensbox/tap/tfswitch
 Installation for Linux operating systems.
 
 ```sh
-curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash
 ```
 
 ## Arch User Repository (AUR) packages for Arch Linux

--- a/www/docs/Continuous-Integration.md
+++ b/www/docs/Continuous-Integration.md
@@ -5,7 +5,7 @@
 #!/bin/bash 
 
 echo "Installing tfswitch locally"
-wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh  #Get the installer on to your machine
+wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh  #Get the installer on to your machine
 
 chmod 755 install.sh #Make installer executable
 
@@ -48,7 +48,7 @@ jobs:
 
             echo "Installing tfswitch locally"
 
-            wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh  #Get the installer on to your machine
+            wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh  #Get the installer on to your machine
 
             chmod 755 install.sh            #Make installer executable
 

--- a/www/docs/Installation.md
+++ b/www/docs/Installation.md
@@ -17,24 +17,24 @@ brew install warrensbox/tap/tfswitch
 Installation for Linux operating systems.
 
 ```sh
-curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash
 ```
 
 By default installer script will try to download `tfswitch` binary into `/usr/local/bin`  
 To install at custom path use below:
 ```sh
-curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b $HOME/.local/bin
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash -s -- -b $HOME/.local/bin
 ```
 
 By default installer script will try to download latest version of `tfswitch` binary  
 To install custom (not latest) version use:
 ```sh
-curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- 1.1.1
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash -s -- 1.1.1
 ```
 
 Both options can be combined though:
 ```sh
-curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash -s -- -b $HOME/.local/bin 1.1.1
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash -s -- -b $HOME/.local/bin 1.1.1
 ```
 
 ## Arch User Repository (AUR) packages for Arch Linux

--- a/www/docs/Installation.md
+++ b/www/docs/Installation.md
@@ -9,7 +9,7 @@ See the [release page](https://github.com/warrensbox/terraform-switcher/releases
 ## Homebrew
 Installation for macOS is the easiest with Homebrew. <a href="https://brew.sh/" target="_blank">If you do not have homebrew installed, click here</a>.
 
-```ruby
+```shell
 brew install warrensbox/tap/tfswitch
 ```
 

--- a/www/docs/Troubleshoot.md
+++ b/www/docs/Troubleshoot.md
@@ -21,7 +21,7 @@ Solution: You probably need to have privileges to install *tfswitch* at /usr/loc
 Try the following:
 
 ```sh
-wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh  #Get the installer on to your machine:
+wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh  #Get the installer on to your machine:
 
 chmod 755 install.sh #Make installer executable
 

--- a/www/docs/Upgrade-or-Uninstall.md
+++ b/www/docs/Upgrade-or-Uninstall.md
@@ -10,7 +10,7 @@ brew upgrade warrensbox/tap/tfswitch
 Rerun:
 
 ```sh
-curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash
 ```
 
 ## Uninstall:

--- a/www/docs/Upgrade-or-Uninstall.md
+++ b/www/docs/Upgrade-or-Uninstall.md
@@ -2,7 +2,7 @@
 
 ### Homebrew
 
-```ruby
+```shell
 brew upgrade warrensbox/tap/tfswitch
 ```
 ### Linux
@@ -17,7 +17,7 @@ curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/i
 
 ### Homebrew
 
-```ruby
+```shell
 brew uninstall warrensbox/tap/tfswitch
 ```
 ### Linux

--- a/www/docs/usage/config-files.md
+++ b/www/docs/usage/config-files.md
@@ -48,7 +48,7 @@ This is similiar to using a .tfswitchrc file, but you can specify a custom binar
 4. Optionally, you can create a `.tfswitch.toml` file in your terraform directory(current directory) OR in your home directory(~/.tfswitch.toml). The toml file in the current directory has a higher precedence than toml file in the home directory
 5. Your `.tfswitch.toml` file should look like this:
 
-```ruby
+```toml
 bin = "$HOME/bin/terraform"
 version = "0.11.3"
 ```
@@ -69,7 +69,7 @@ bin = "C:\\Users\\<%USRNAME%>\\bin\\terraform.exe"
 If a terragrunt.hcl file with the terraform constraint is included in the current directory, it should automatically download or switch to that terraform version.  
 For example, the following should automatically switch terraform to the lastest version 0.13:
 
-```ruby
+```hcl
 terragrunt_version_constraint = ">= 0.26, < 0.27"
 terraform_version_constraint  = ">= 0.13, < 0.14"
 ...


### PR DESCRIPTION
Fix links to `install.sh` after moving from `release` to `master` branch as main branch

fixes #431