### PR TITLE
fix: Remove duplicate .exe extension added to paths for windows inside symlink, as this is already handled by ConvertExecutableExt

### DIFF
--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -20,9 +20,9 @@ func CreateSymlink(cwd string, dir string) error {
 		}
 		defer r.Close()
 
-		w, err := os.Create(dir + ".exe")
+		w, err := os.Create(dir)
 		if err != nil {
-			return fmt.Errorf("Could not create target binary: %q.exe", dir)
+			return fmt.Errorf("Could not create target binary: %q", dir)
 		}
 		defer func() {
 			if c := w.Close(); err == nil {

--- a/lib/symlink_test.go
+++ b/lib/symlink_test.go
@@ -48,7 +48,7 @@ func TestCreateSymlink(t *testing.T) {
 	CreateSymlink(symlinkPathDest, symlinkPathSrc)
 
 	if runtime.GOOS == "windows" {
-		_, err := os.Stat(symlinkPathSrc + ".exe")
+		_, err := os.Stat(symlinkPathSrc)
 		if err != nil {
 			t.Logf("Could not stat file copy at %v. [unexpected]", symlinkPathSrc)
 			t.Error("File copy was not created.")


### PR DESCRIPTION

Issue #480