### PR TITLE
feat: Add Multi Labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@
 version: v1
 
 labels:
-  - label: 'dependency'
+  - label: 'dependencies'
     matcher:
       title: '^deps:'
       branch: '^deps/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+# https://github.com/fuxingloh/multi-labeler
+# https://www.conventionalcommits.org/
+# https://github.com/warrensbox/terraform-switcher/labels
+
+version: v1
+
+labels:
+  - label: 'dependency'
+    matcher:
+      title: '^deps:'
+      branch: '^deps/'
+      commits: '^deps:'
+
+  - label: 'documentation'
+    matcher:
+      title: '^docs?:'
+      branch: '^docs?/'
+      commits: '^docs?:'
+
+  - label: 'enhancement'
+    matcher:
+      title: '^fix:'
+      branch: '^fix/'
+      commits: '^fix:'
+
+  - label: 'golang'
+    matcher:
+      title: '^go(lang)?:'
+      branch: '^go(lang)?/'
+      commits: '^go(lang)?:'
+
+  - label: 'new feature'
+    matcher:
+      title: '^feat(ure)?:'
+      branch: '^feat(ure)?/'
+      commits: '^feat(ure)?:'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,13 +3,14 @@ changelog:
   categories:
     - title: Added
       labels:
-        - enhancement
+        - experimental
         - feature
         - new feature
     - title: Changed
       labels:
         - backwards-incompatible
         - depricated
+        - enhancement
     - title: Fixed
       labels:
         - bug
@@ -20,6 +21,9 @@ changelog:
       labels:
         - docs
         - documentation
+    - title: Security
+      labels:
+        - security
     - title: Dependencies
       labels:
         - dependencies

--- a/.github/workflows/multi-labeler.yml
+++ b/.github/workflows/multi-labeler.yml
@@ -1,0 +1,19 @@
+# https://github.com/fuxingloh/multi-labeler
+# https://www.conventionalcommits.org/
+# https://github.com/warrensbox/terraform-switcher/labels
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+    branches: [master, main]
+
+  pull_request_target: # for OSS with public contributions (forked PR)
+    types: [opened, edited, synchronize, ready_for_review]
+    branches: [master, main]
+
+jobs:
+  labeler:
+    name: Multi Labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fuxingloh/multi-labeler@v4


### PR DESCRIPTION
Auto label PRs based on title, commit message, and branch name.

PR labels are used to structure and group [CHANGELOG entries](/CHANGELOG.howto.md) and [auto-generated Release change logs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).

Refs:
- https://github.com/fuxingloh/multi-labeler
- https://www.conventionalcommits.org/
- https://github.com/warrensbox/terraform-switcher/labels