### PR TITLE
fix: Improve wording when installing binary

### DIFF
--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -122,7 +122,7 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 	}
 
 	if err == nil {
-		return fmt.Printf("None of the installation directories exist: \"%s\". %s\n",
+		return fmt.Errorf("None of the installation directories exist: \"%s\". %s\n",
 			strings.Join(possibleInstallLocations, `", "`),
 			"Manually create one of them and try again.")
 	}

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -101,11 +101,11 @@ func ChangeSymlink(binVersionPath string, binPath string) {
 func ChangeProductSymlink(product Product, binVersionPath string, userBinPath string) error {
 	homedir := GetHomeDirectory() // get user's home directory
 	homeBinPath := filepath.Join(homedir, "bin", product.GetExecutableName())
-	possibleInstallLocations := []string{userBinPath, homeBinPath}
+	possibleInstallLocations := []string{Path(userBinPath), Path(homeBinPath)}
 	var err error
 
 	for _, location := range possibleInstallLocations {
-		if CheckDirExist(Path(location)) {
+		if CheckDirExist(location) {
 			/* remove current symlink if exist*/
 			symlinkExist := CheckSymlink(location)
 			if symlinkExist {
@@ -122,8 +122,8 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 	}
 
 	if err == nil {
-		return fmt.Errorf("Unable to find existing directory in %q. %s",
-			strings.Join(possibleInstallLocations, " or "),
+		return fmt.Printf("None of the installation directories exist: \"%s\". %s\n",
+			strings.Join(possibleInstallLocations, `", "`),
 			"Manually create one of them and try again.")
 	}
 

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -101,11 +101,13 @@ func ChangeSymlink(binVersionPath string, binPath string) {
 func ChangeProductSymlink(product Product, binVersionPath string, userBinPath string) error {
 	homedir := GetHomeDirectory() // get user's home directory
 	homeBinPath := filepath.Join(homedir, "bin", product.GetExecutableName())
-	possibleInstallLocations := []string{Path(userBinPath), Path(homeBinPath)}
+	possibleInstallLocations := []string{userBinPath, homeBinPath}
+	possibleInstallDirs := []string{}
 	var err error
 
 	for _, location := range possibleInstallLocations {
-		if CheckDirExist(location) {
+		possibleInstallDirs = append(possibleInstallDirs, Path(location))
+		if CheckDirExist(Path(location)) {
 			/* remove current symlink if exist*/
 			symlinkExist := CheckSymlink(location)
 			if symlinkExist {
@@ -123,7 +125,7 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 
 	if err == nil {
 		return fmt.Errorf("None of the installation directories exist: \"%s\". %s\n",
-			strings.Join(possibleInstallLocations, `", "`),
+			strings.Join(possibleInstallDirs, `", "`),
 			"Manually create one of them and try again.")
 	}
 


### PR DESCRIPTION
fixes #493

OLD:
```
Unable to find existing directory in "/usr/local/bin/terraform or /Users/${CURRENT_USER}/bin/terraform". Manually create one of them and try again.
```
NEW
```
None of the installation directories exist: "/usr/local/bin", "/home/${CURRENT_USER}/bin". Manually create one of them and try again.
```