### PR TITLE
feat: Override default build format to Zip when building for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,8 @@ version: 2
 env:
   - CGO_ENABLED=0 # Build statically linked binaries
 
+
+
 builds:
   -
     ldflags:
@@ -37,6 +39,9 @@ archives:
       {{- .Os }}_
       {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
+    format_overrides:
+      - goos: windows
+        format: zip
 
 brews:
   -


### PR DESCRIPTION
Override default build format to Zip when building for Windows

The idea behind it is to enable winget installation due the inability of winget decompress tar files.