### PR TITLE
feat: Allow to download binary with custom CPU arch

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -115,7 +115,9 @@ func switchToVersion(product Product, tfversion string, binPath string, installP
 	}
 
 	logger.Infof("Switched %s to version %q", product.GetName(), tfversion)
-	addRecent(tfversion, installPath, product) // add to recent file for faster lookup
+
+	// add to recent file for faster lookup
+	addRecent(tfversion, installPath, product)
 	return nil
 }
 

--- a/lib/param_parsing/environment.go
+++ b/lib/param_parsing/environment.go
@@ -3,6 +3,10 @@ package param_parsing
 import "os"
 
 func GetParamsFromEnvironment(params Params) Params {
+	if envArch := os.Getenv("TF_ARCH"); envArch != "" {
+		params.Arch = envArch
+		logger.Debugf("Using architecture from environment variable \"TF_ARCH\": %q", envArch)
+	}
 	if envVersion := os.Getenv("TF_VERSION"); envVersion != "" {
 		params.Version = envVersion
 		logger.Debugf("Using version from environment variable \"TF_VERSION\": %q", envVersion)

--- a/lib/param_parsing/environment_test.go
+++ b/lib/param_parsing/environment_test.go
@@ -15,7 +15,7 @@ func TestGetParamsFromEnvironment_arch_from_env(t *testing.T) {
 	params = initParams(params)
 	params = GetParamsFromEnvironment(params)
 	_ = os.Unsetenv("TF_ARCH")
-	if params.Version != expected {
+	if params.Arch != expected {
 		t.Error("Determined arch is not matching. Got " + params.Arch + ", expected " + expected)
 	}
 }

--- a/lib/param_parsing/environment_test.go
+++ b/lib/param_parsing/environment_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/warrensbox/terraform-switcher/lib"
 )
 
+func TestGetParamsFromEnvironment_arch_from_env(t *testing.T) {
+	logger = lib.InitLogger("DEBUG")
+	var params Params
+	expected := "amd64_from_env"
+	_ = os.Setenv("TF_ARCH", expected)
+	params = initParams(params)
+	params = GetParamsFromEnvironment(params)
+	_ = os.Unsetenv("TF_ARCH")
+	if params.Version != expected {
+		t.Error("Determined arch is not matching. Got " + params.Arch + ", expected " + expected)
+	}
+}
+
 func TestGetParamsFromEnvironment_version_from_env(t *testing.T) {
 	logger = lib.InitLogger("DEBUG")
 	var params Params

--- a/lib/param_parsing/parameters.go
+++ b/lib/param_parsing/parameters.go
@@ -12,6 +12,7 @@ import (
 )
 
 type Params struct {
+	Arch             string
 	ChDirPath        string
 	CustomBinaryPath string
 	DefaultVersion   string
@@ -51,6 +52,7 @@ func populateParams(params Params) Params {
 		defaultMirrors = append(defaultMirrors, fmt.Sprintf("%s: %s", product.GetName(), product.GetDefaultMirrorUrl()))
 	}
 
+	getopt.StringVarLong(&params.Arch, "arch", 'A', fmt.Sprintf("Override CPU architecture type for downloaded binary. Ex: `tfswitch --arch amd64` will attempt to download the amd64 version of the binary. Default: %s", runtime.GOARCH))
 	getopt.StringVarLong(&params.ChDirPath, "chdir", 'c', "Switch to a different working directory before executing the given command. Ex: tfswitch --chdir terraform_project will run tfswitch in the terraform_project directory")
 	getopt.StringVarLong(&params.CustomBinaryPath, "bin", 'b', "Custom binary path. Ex: tfswitch -b "+lib.ConvertExecutableExt("/Users/username/bin/terraform"))
 	getopt.StringVarLong(&params.DefaultVersion, "default", 'd', "Default to this version in case no other versions could be detected. Ex: tfswitch --default 1.2.4")
@@ -160,6 +162,7 @@ func populateParams(params Params) Params {
 }
 
 func initParams(params Params) Params {
+	params.Arch = runtime.GOARCH
 	params.ChDirPath = lib.GetCurrentDirectory()
 	params.CustomBinaryPath = ""
 	params.DefaultVersion = lib.DefaultLatest

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestGetParameters_arch_from_args(t *testing.T) {
-	expected := "amd64"
-	os.Args = []string{"cmd", expected}
+	expected := "arch_from_args"
+	os.Args = []string{"cmd", "--arch=" + expected}
 	params := GetParameters()
 	actual := params.Arch
 	if actual != expected {

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/warrensbox/terraform-switcher/lib"
 )
 
+func TestGetParameters_arch_from_args(t *testing.T) {
+	expected := "amd64args"
+	os.Args = []string{"cmd", expected}
+	params := GetParameters()
+	actual := params.Arch
+	if actual != expected {
+		t.Error("Arch Param was not parsed correctly. Actual: " + actual + ", Expected: " + expected)
+	}
+	t.Cleanup(func() {
+		getopt.CommandLine = getopt.New()
+	})
+}
+
 func TestGetParameters_version_from_args(t *testing.T) {
 	expected := "0.13args"
 	os.Args = []string{"cmd", expected}
@@ -45,6 +58,12 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 		t.Error("CustomBinaryPath Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
 
+	expected = "amd64"
+	actual = params.Arch
+	if actual != expected {
+		t.Error("Arch Param was not as expected. Actual: " + actual + ", Expected: " + expected)
+	}
+
 	expected = "1.6.2"
 	actual = params.Version
 	if actual != expected {
@@ -64,7 +83,7 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 func TestGetParameters_toml_params_are_overridden_by_cli(t *testing.T) {
 	logger = lib.InitLogger("DEBUG")
 	expected := "../../test-data/integration-tests/test_tfswitchtoml"
-	os.Args = []string{"cmd", "--chdir=" + expected, "--bin=/usr/test/bin", "--product=terraform", "1.6.0"}
+	os.Args = []string{"cmd", "--chdir=" + expected, "--bin=/usr/test/bin", "--product=terraform", "--arch=amd64", "1.6.0"}
 	params := Params{}
 	params = initParams(params)
 	params.TomlDir = expected
@@ -91,6 +110,12 @@ func TestGetParameters_toml_params_are_overridden_by_cli(t *testing.T) {
 	actual = params.Product
 	if actual != expected {
 		t.Error("Product Param was not as expected. Actual: " + actual + ", Expected: " + expected)
+	}
+
+	expected = "amd64"
+	actual = params.Arch
+	if actual != expected {
+		t.Error("Arch Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
 
 	t.Cleanup(func() {

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -83,7 +83,7 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 func TestGetParameters_toml_params_are_overridden_by_cli(t *testing.T) {
 	logger = lib.InitLogger("DEBUG")
 	expected := "../../test-data/integration-tests/test_tfswitchtoml"
-	os.Args = []string{"cmd", "--chdir=" + expected, "--bin=/usr/test/bin", "--product=terraform", "--arch=amd64", "1.6.0"}
+	os.Args = []string{"cmd", "--chdir=" + expected, "--bin=/usr/test/bin", "--product=terraform", "--arch=arch_from_args", "1.6.0"}
 	params := Params{}
 	params = initParams(params)
 	params.TomlDir = expected
@@ -112,7 +112,7 @@ func TestGetParameters_toml_params_are_overridden_by_cli(t *testing.T) {
 		t.Error("Product Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
 
-	expected = "amd64"
+	expected = "arch_from_args"
 	actual = params.Arch
 	if actual != expected {
 		t.Error("Arch Param was not as expected. Actual: " + actual + ", Expected: " + expected)

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -137,7 +137,7 @@ func TestGetParameters_dry_run_wont_download_anything(t *testing.T) {
 	installFileVersionPath := lib.ConvertExecutableExt(filepath.Join(installLocation, product.GetVersionPrefix()+params.Version))
 	// Make sure the file tfswitch WOULD download is absent
 	_ = os.Remove(installFileVersionPath)
-	lib.InstallProductVersion(product, params.DryRun, params.Version, params.CustomBinaryPath, params.InstallPath, params.MirrorURL)
+	lib.InstallProductVersion(product, params.DryRun, params.Version, params.CustomBinaryPath, params.InstallPath, params.MirrorURL, params.Arch)
 	if lib.FileExistsAndIsNotDir(installFileVersionPath) {
 		t.Error("Dry run should NOT download any files.")
 	}
@@ -148,7 +148,7 @@ func TestGetParameters_dry_run_wont_download_anything(t *testing.T) {
 
 func writeTestFile(t *testing.T, basePath string, fileName string, fileContent string) {
 	fullPath := filepath.Join(basePath, fileName)
-	if err := os.WriteFile(fullPath, []byte(fileContent), 0600); err != nil {
+	if err := os.WriteFile(fullPath, []byte(fileContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGetParameters_arch_from_args(t *testing.T) {
-	expected := "amd64args"
+	expected := "amd64"
 	os.Args = []string{"cmd", expected}
 	params := GetParameters()
 	actual := params.Arch

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -27,6 +27,10 @@ func getParamsTOML(params Params) (Params, error) {
 			return params, errs
 		}
 
+		if viperParser.Get("arch") != nil {
+			params.Arch = os.ExpandEnv(viperParser.GetString("arch"))
+			logger.Debugf("Using \"arch\" from %q: %q", tomlPath, params.Arch)
+		}
 		if viperParser.Get("bin") != nil {
 			params.CustomBinaryPath = os.ExpandEnv(viperParser.GetString("bin"))
 			logger.Debugf("Using \"bin\" from %q: %q", tomlPath, params.CustomBinaryPath)

--- a/main.go
+++ b/main.go
@@ -25,12 +25,13 @@ import (
 	"github.com/warrensbox/terraform-switcher/lib/param_parsing"
 )
 
-var parameters = param_parsing.GetParameters()
-var logger = lib.InitLogger(parameters.LogLevel)
-var version string
+var (
+	parameters = param_parsing.GetParameters()
+	logger     = lib.InitLogger(parameters.LogLevel)
+	version    string
+)
 
 func main() {
-
 	var err error = nil
 	switch {
 	case parameters.VersionFlag:
@@ -45,33 +46,33 @@ func main() {
 		os.Exit(0)
 	case parameters.ListAllFlag:
 		/* show all terraform version including betas and RCs*/
-		err = lib.InstallProductOption(parameters.ProductEntity, true, parameters.DryRun, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL)
+		err = lib.InstallProductOption(parameters.ProductEntity, true, parameters.DryRun, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch)
 	case parameters.LatestPre != "":
 		/* latest pre-release implicit version. Ex: tfswitch --latest-pre 0.13 downloads 0.13.0-rc1 (latest) */
-		err = lib.InstallLatestProductImplicitVersion(parameters.ProductEntity, parameters.DryRun, parameters.LatestPre, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, true)
+		err = lib.InstallLatestProductImplicitVersion(parameters.ProductEntity, parameters.DryRun, parameters.LatestPre, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch, true)
 	case parameters.ShowLatestPre != "":
 		/* show latest pre-release implicit version. Ex: tfswitch --latest-pre 0.13 downloads 0.13.0-rc1 (latest) */
 		lib.ShowLatestImplicitVersion(parameters.ShowLatestPre, parameters.MirrorURL, true)
 	case parameters.LatestStable != "":
 		/* latest implicit version. Ex: tfswitch --latest-stable 0.13 downloads 0.13.5 (latest) */
-		err = lib.InstallLatestProductImplicitVersion(parameters.ProductEntity, parameters.DryRun, parameters.LatestStable, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, false)
+		err = lib.InstallLatestProductImplicitVersion(parameters.ProductEntity, parameters.DryRun, parameters.LatestStable, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch, false)
 	case parameters.ShowLatestStable != "":
 		/* show latest implicit stable version. Ex: tfswitch --show-latest-stable 0.13 downloads 0.13.5 (latest) */
 		lib.ShowLatestImplicitVersion(parameters.ShowLatestStable, parameters.MirrorURL, false)
 	case parameters.LatestFlag:
 		/* latest stable version */
-		err = lib.InstallLatestProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL)
+		err = lib.InstallLatestProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch)
 	case parameters.ShowLatestFlag:
 		/* show latest stable version */
 		lib.ShowLatestVersion(parameters.MirrorURL)
 	case parameters.Version != "":
-		err = lib.InstallProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.Version, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL)
+		err = lib.InstallProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.Version, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch)
 	case parameters.DefaultVersion != "":
 		/* if default version is provided - Pick this instead of going for prompt */
-		err = lib.InstallProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.DefaultVersion, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL)
+		err = lib.InstallProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.DefaultVersion, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch)
 	default:
 		// Set list all false - only official release will be displayed
-		err = lib.InstallProductOption(parameters.ProductEntity, false, parameters.DryRun, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL)
+		err = lib.InstallProductOption(parameters.ProductEntity, false, parameters.DryRun, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch)
 	}
 	if err != nil {
 		logger.Fatal(err)

--- a/test-data/integration-tests/test_tfswitchtoml/.tfswitch.toml
+++ b/test-data/integration-tests/test_tfswitchtoml/.tfswitch.toml
@@ -1,5 +1,6 @@
+arch = "amd64"
 bin = "/usr/local/bin/terraform_from_toml"
-version = "1.6.2"
+default-version = "1.5.4"
 log-level = "NOTICE"
 product = "opentofu"
-default-version = "1.5.4"
+version = "1.6.2"

--- a/www/docs/usage/commandline.md
+++ b/www/docs/usage/commandline.md
@@ -33,7 +33,7 @@ For example:
 
 ```bash
 export TF_VERSION=0.14.4
-tfswitch #will automatically switch to terraform version 0.14.4
+tfswitch # Will automatically switch to terraform version 0.14.4
 ```
 
 ### `TF_DEFAULT_VERSION`
@@ -44,7 +44,7 @@ For example:
 
 ```bash
 export TF_DEFAULT_VERSION=0.14.4
-tfswitch #will automatically switch to terraform version 0.14.4
+tfswitch # Will automatically switch to terraform version 0.14.4
 ```
 
 ### `TF_PRODUCT`
@@ -60,7 +60,24 @@ For example:
 
 ```bash
 export TF_PRODUCT=opentofu
-tfswitch # Will install opentofu
+tfswitch # Will install opentofu instead of terraform
+```
+
+### `TF_ARCH`
+
+`TF_ARCH` environment variable can be set to override default CPU architecture for downloaded Terraform binary.
+
+- This can be set to any string, though incorrect values will result in download failure.
+- Suggested values: `amd64`, `arm64`, `386`.
+- Check available Arch types at:
+  - [Terraform Downloads](https://releases.hashicorp.com/terraform/)
+  - [OpenTofu Downloads](https://get.opentofu.org/tofu/)
+
+For example:
+
+```bash
+export TF_ARCH=amd64
+tfswitch # Will install Terraform binary for amd64 architecture
 ```
 
 ## Install latest version only
@@ -119,4 +136,16 @@ The Terraform binaries will then be placed in the directory `.terraform.versions
 tfswitch -i /opt/terraform
 ```
 
-**NOTE** - The directory passed in `-i`/`--install` must be created before running `tfswitch`
+**NOTE**: The directory passed in `-i`/`--install` must be created before running `tfswitch`
+
+## Install binary for non-default architecture
+
+By default `tfswitch` will download the binary for the architecture of the host machine.
+
+If you want to download the binary for non-default CPU architecture then you can provide the `-A` or `--arch` command line argument to download binaries for custom CPU architecture. Useful if you need to override binary architecture for whatever reason.
+
+```bash
+tfswitch --arch amd64
+```
+
+**NOTE**: If the target file already exists in the download directory (See [Install to non-default location](#install-to-non-default-location) section above), it will be not downloaded. Downloaded files are stored without the architecture in the filename. Format of the filenames in download directory: `<product>_<version>`. E.g. `terraform_1.10.4`.


### PR DESCRIPTION
Fixes #318

Note: code in changed files is auto-formatted

Caveats:
- Supports overriding arch via env var and TOML config
- Doesn't override if binary had already been downloaded before
  - Remove existing binary from `tfswitch` download dir manually (see `--install` option)
- Spits out Warn log message if requested arch doesn't match actual
- Doesn't check arch value validity and just passes it to download function directly, which will fail if download file doesn't exist on remote

Usage example: `tfswitch --arch arm64 1.10.0`
![image](https://github.com/user-attachments/assets/bc4d5e70-395f-429e-99a1-86ae69612fa2)
OpenTofu (for completeness):
![image](https://github.com/user-attachments/assets/0e20513a-4af6-422f-9650-5510ed06cc97)
