### PR TITLE
docs: Update CHANGELOG with `v1.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.3.0](https://github.com/warrensbox/terraform-switcher/tree/v1.3.0) - 2025-01-26
+
+[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.2.4...v1.3.0)
+
+### Added
+
+- feat: Allow to download binary with custom CPU arch [#532](https://github.com/warrensbox/terraform-switcher/pull/532) ([yermulnik](https://github.com/yermulnik))
+
+### Fixed
+
+- fix(Makefile): bring up to date [#535](https://github.com/warrensbox/terraform-switcher/pull/535) ([yermulnik](https://github.com/yermulnik))
+- fix: Exclude CHANGELOG howto from distribution archives [#528](https://github.com/warrensbox/terraform-switcher/pull/528) ([yermulnik](https://github.com/yermulnik))
+
+### Other
+
+- docs: TOML file belongs in Home dir only [#534](https://github.com/warrensbox/terraform-switcher/pull/534) ([yermulnik](https://github.com/yermulnik))
+- docs: Update CHANGELOG with `v1.2.4` [#520](https://github.com/warrensbox/terraform-switcher/pull/520) ([yermulnik](https://github.com/yermulnik))
+
 ## [v1.2.4](https://github.com/warrensbox/terraform-switcher/tree/v1.2.4) - 2024-11-23
 
 [Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.2.3...v1.2.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Other
 
+- docs: Update CHANGELOG with `v1.3.0` [#538](https://github.com/warrensbox/terraform-switcher/pull/538) ([yermulnik](https://github.com/yermulnik))
 - docs: TOML file belongs in Home dir only [#534](https://github.com/warrensbox/terraform-switcher/pull/534) ([yermulnik](https://github.com/yermulnik))
 - docs: Update CHANGELOG with `v1.2.4` [#520](https://github.com/warrensbox/terraform-switcher/pull/520) ([yermulnik](https://github.com/yermulnik))
 

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -211,6 +211,21 @@ func ShowLatestVersion(mirrorURL string) {
 	fmt.Printf("%s\n", tfversion)
 }
 
+// ShowLatestRequiredVersion show latest version using constraints from TF
+func ShowLatestRequiredVersion(mirrorURL string, version string) {
+	if version == "" {
+		ShowLatestVersion(mirrorURL)
+		return
+	}
+	// Ensure version passed in valid and didn't come from an argument
+	tflist, _ := getTFList(mirrorURL, true)
+	if versionExist(version, tflist) {
+		fmt.Printf("%s\n", version)
+		return
+	}
+	logger.Fatal("The provided terraform version does not exist.")
+}
+
 // ShowLatestImplicitVersion show latest - argument (version) must be provided
 func ShowLatestImplicitVersion(requestedVersion, mirrorURL string, preRelease bool) {
 	if validMinorVersionFormat(requestedVersion) {

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -205,7 +205,7 @@ func validMinorVersionFormat(version string) bool {
 	return semverRegex.MatchString(version)
 }
 
-// ShowLatestVersion show install latest stable tf version
+// ShowLatestVersion show latest stable tf version
 func ShowLatestVersion(mirrorURL string) {
 	tfversion, _ := getTFLatest(mirrorURL)
 	fmt.Printf("%s\n", tfversion)

--- a/lib/param_parsing/parameters.go
+++ b/lib/param_parsing/parameters.go
@@ -12,27 +12,28 @@ import (
 )
 
 type Params struct {
-	Arch             string
-	ChDirPath        string
-	CustomBinaryPath string
-	DefaultVersion   string
-	DryRun           bool
-	HelpFlag         bool
-	InstallPath      string
-	LatestFlag       bool
-	LatestPre        string
-	LatestStable     string
-	ListAllFlag      bool
-	LogLevel         string
-	MirrorURL        string
-	ShowLatestFlag   bool
-	ShowLatestPre    string
-	ShowLatestStable string
-	Product          string
-	ProductEntity    lib.Product
-	TomlDir          string
-	Version          string
-	VersionFlag      bool
+	Arch                   string
+	ChDirPath              string
+	CustomBinaryPath       string
+	DefaultVersion         string
+	DryRun                 bool
+	HelpFlag               bool
+	InstallPath            string
+	LatestFlag             bool
+	LatestPre              string
+	LatestStable           string
+	ListAllFlag            bool
+	LogLevel               string
+	MirrorURL              string
+	ShowLatestFlag         bool
+	ShowLatestPre          string
+	ShowLatestRequiredFlag bool
+	ShowLatestStable       string
+	Product                string
+	ProductEntity          lib.Product
+	TomlDir                string
+	Version                string
+	VersionFlag            bool
 }
 
 var logger *slog.Logger
@@ -66,6 +67,7 @@ func populateParams(params Params) Params {
 	getopt.StringVarLong(&params.LogLevel, "log-level", 'g', "Set loglevel for tfswitch. One of (ERROR, INFO, NOTICE, DEBUG, TRACE)")
 	getopt.StringVarLong(&params.MirrorURL, "mirror", 'm', "install from a remote API other than the default. Default (based on product):\n"+strings.Join(defaultMirrors, "\n"))
 	getopt.BoolVarLong(&params.ShowLatestFlag, "show-latest", 'U', "Show latest stable version")
+	getopt.BoolVarLong(&params.ShowLatestRequiredFlag, "show-latest-required", 'R', "Show latest stable version, which complies to constraints set by Terraform/Terragrunt")
 	getopt.StringVarLong(&params.ShowLatestPre, "show-latest-pre", 'P', "Show latest pre-release implicit version. Ex: tfswitch --show-latest-pre 0.13 prints 0.13.0-rc1 (latest)")
 	getopt.StringVarLong(&params.ShowLatestStable, "show-latest-stable", 'S', "Show latest implicit version. Ex: tfswitch --show-latest-stable 0.13 prints 0.13.7 (latest)")
 	getopt.StringVarLong(&params.Product, "product", 't', fmt.Sprintf("Specifies which product to use. Ex: `tfswitch --product opentofu` will install OpenTofu. Options: (%s). Default: %s", strings.Join(productIds, ", "), lib.DefaultProductId))
@@ -177,6 +179,7 @@ func initParams(params Params) Params {
 	params.MirrorURL = ""
 	params.ShowLatestFlag = false
 	params.ShowLatestPre = lib.DefaultLatest
+	params.ShowLatestRequiredFlag = false
 	params.ShowLatestStable = lib.DefaultLatest
 	params.TomlDir = lib.GetHomeDirectory()
 	params.Version = lib.DefaultLatest

--- a/lib/param_parsing/versiontf.go
+++ b/lib/param_parsing/versiontf.go
@@ -72,5 +72,5 @@ func isTerraformModule(params Params) bool {
 	if len(module.RequiredCore) == 0 {
 		logger.Debugf("No required version constraints defined by Terraform module at %q", params.ChDirPath)
 	}
-	return err == nil && len(module.RequiredCore) > 0
+	return len(module.RequiredCore) > 0
 }

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ func main() {
 	case parameters.ShowLatestFlag:
 		/* show latest stable version */
 		lib.ShowLatestVersion(parameters.MirrorURL)
+	case parameters.ShowLatestRequiredFlag:
+		/* show latest stable version within constraints */
+		lib.ShowLatestRequiredVersion(parameters.MirrorURL, parameters.Version)
 	case parameters.Version != "":
 		err = lib.InstallProductVersion(parameters.ProductEntity, parameters.DryRun, parameters.Version, parameters.CustomBinaryPath, parameters.InstallPath, parameters.MirrorURL, parameters.Arch)
 	case parameters.DefaultVersion != "":


### PR DESCRIPTION
### Added

- feat: Allow to download binary with custom CPU arch [#532](https://github.com/warrensbox/terraform-switcher/pull/532) ([yermulnik](https://github.com/yermulnik))

### Fixed

- fix(Makefile): bring up to date [#535](https://github.com/warrensbox/terraform-switcher/pull/535) ([yermulnik](https://github.com/yermulnik))
- fix: Exclude CHANGELOG howto from distribution archives [#528](https://github.com/warrensbox/terraform-switcher/pull/528) ([yermulnik](https://github.com/yermulnik))

### Other

- docs: Update CHANGELOG with `v1.3.0` [#538](https://github.com/warrensbox/terraform-switcher/pull/538) ([yermulnik](https://github.com/yermulnik))
- docs: TOML file belongs in Home dir only [#534](https://github.com/warrensbox/terraform-switcher/pull/534) ([yermulnik](https://github.com/yermulnik))
- docs: Update CHANGELOG with `v1.2.4` [#520](https://github.com/warrensbox/terraform-switcher/pull/520) ([yermulnik](https://github.com/yermulnik))