### PR TITLE
feat: Improve messaging

### DIFF
--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -66,7 +66,7 @@ func checkSignatureOfChecksums(keyRingReader *os.File, hashFile *os.File, signat
 	fileHandlersToClose = append(fileHandlersToClose, signatureFile)
 	defer closeFileHandlers(fileHandlersToClose)
 
-	logger.Info("Verifying signature of checksum file...")
+	logger.Info("Verifying signature of checksum file")
 	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)
 	if err != nil {
 		logger.Errorf("Could not read armored key ring: %v", err)
@@ -78,6 +78,6 @@ func checkSignatureOfChecksums(keyRingReader *os.File, hashFile *os.File, signat
 		logger.Errorf("Could not check detached signature: %v", err)
 		return false
 	}
-	logger.Info("Checksum file signature verification successful.")
+	logger.Info("Checksum file signature verification successful")
 	return true
 }

--- a/lib/download.go
+++ b/lib/download.go
@@ -15,6 +15,7 @@ func DownloadFromURL(installLocation, mirrorURL, tfversion, versionPrefix, goos,
 	product := getLegacyProduct()
 	return DownloadProductFromURL(product, installLocation, mirrorURL, tfversion, versionPrefix, goos, goarch)
 }
+
 func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversion, versionPrefix, goos, goarch string) (string, error) {
 	var wg sync.WaitGroup
 	defer wg.Done()
@@ -24,28 +25,28 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 
 	pubKeyFilename, err := downloadPublicKey(product, installLocation, &wg)
 	if err != nil {
-		logger.Error("Could not download public PGP key file.")
+		logger.Error("Could not download public PGP key file")
 		return "", err
 	}
 
 	logger.Infof("Downloading %q", zipUrl)
 	zipFilePath, err := downloadFromURL(installLocation, zipUrl, &wg)
 	if err != nil {
-		logger.Error("Could not download zip file.")
+		logger.Error("Could not download zip file")
 		return "", err
 	}
 
 	logger.Infof("Downloading %q", hashUrl)
 	hashFilePath, err := downloadFromURL(installLocation, hashUrl, &wg)
 	if err != nil {
-		logger.Error("Could not download hash file.")
+		logger.Error("Could not download hash file")
 		return "", err
 	}
 
 	logger.Infof("Downloading %q", hashSignatureUrl)
 	hashSigFilePath, err := downloadFromURL(installLocation, hashSignatureUrl, &wg)
 	if err != nil {
-		logger.Error("Could not download hash signature file.")
+		logger.Error("Could not download hash signature file")
 		return "", err
 	}
 
@@ -106,8 +107,8 @@ func downloadFromURL(installLocation string, url string, wg *sync.WaitGroup) (st
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
-		//Sometimes hashicorp terraform file names are not consistent
-		//For example 0.12.0-alpha4 naming convention in the release repo is not consistent
+		// Sometimes hashicorp terraform file names are not consistent
+		// For example 0.12.0-alpha4 naming convention in the release repo is not consistent
 		return "", errors.New("Unable to download from " + url)
 	}
 

--- a/lib/files.go
+++ b/lib/files.go
@@ -85,7 +85,7 @@ func Unzip(src string, dest string, fileToUnzipSlice ...string) ([]string, error
 			filenames = append(filenames, filepath.Join(destination, f.Name))
 		}
 	}
-	logger.Debug("Waiting for deferred functions.")
+	logger.Debug("Waiting for deferred functions")
 	unzipWaitGroup.Wait()
 
 	if len(filenames) < 1 {
@@ -101,7 +101,7 @@ func Unzip(src string, dest string, fileToUnzipSlice ...string) ([]string, error
 func createDirIfNotExist(dir string) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		logger.Infof("Creating %q directory", dir)
-		err = os.MkdirAll(dir, 0755)
+		err = os.MkdirAll(dir, 0o755)
 		if err != nil {
 			logger.Panicf("Unable to create %q directory: %v", dir, err)
 		}

--- a/lib/install.go
+++ b/lib/install.go
@@ -65,7 +65,7 @@ func install(product Product, tfversion, binPath, installPath, mirrorURL, goarch
 	exist := versionExist(tfversion, tflist) // Check if version exists before downloading it
 
 	if !exist {
-		return fmt.Errorf("the provided %s version does not exist: %q.\n Try `tfswitch -l` to see all available versions", product.GetId(), tfversion)
+		return fmt.Errorf("Provided %s version does not exist: %q.\n\tTry `tfswitch -l` to see all available versions", product.GetId(), tfversion)
 	}
 
 	if goarch != runtime.GOARCH {
@@ -96,7 +96,7 @@ func install(product Product, tfversion, binPath, installPath, mirrorURL, goarch
 		logger.Fatalf("Unable to unzip %q file: %v", zipFile, errUnzip)
 	}
 
-	logger.Debug("Waiting for deferred functions.")
+	logger.Debug("Waiting for deferred functions")
 	wg.Wait()
 	/* rename unzipped file to terraform version name - terraform_x.x.x */
 	installFilePath := ConvertExecutableExt(filepath.Join(installLocation, product.GetExecutableName()))
@@ -166,7 +166,7 @@ func installableBinLocation(product Product, userBinPath string) string {
 		}
 	}
 
-	logger.Fatalf("Binary path (%q) does not exist. Manually create bin directory %q and try again.", userBinPath, binDir)
+	logger.Fatalf("Binary path (%q) does not exist. Manually create bin directory %q and try again", userBinPath, binDir)
 	os.Exit(1)
 	return ""
 }
@@ -229,8 +229,7 @@ func InstallProductVersion(product Product, dryRun bool, version, customBinaryPa
 			return install(product, requestedVersion, customBinaryPath, installPath, mirrorURL, arch)
 		} else {
 			PrintInvalidTFVersion()
-			UsageMessage()
-			return fmt.Errorf("args must be a valid terraform version")
+			return fmt.Errorf("Argument must be a valid %s version", product.GetName())
 		}
 	}
 	return nil

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -31,7 +31,7 @@ func getVersionsFromBody(body string, preRelease bool, tfVersionList *tfVersionL
 		return
 	}
 	for _, match := range matches {
-		trimstr := strings.Trim(match, "/\"") //remove '/' or '"' from /X.X.X/" or /X.X.X"
+		trimstr := strings.Trim(match, "/\"") // remove '/' or '"' from /X.X.X/" or /X.X.X"
 		tfVersionList.tflist = append(tfVersionList.tflist, trimstr)
 	}
 }
@@ -66,7 +66,7 @@ func getTFLatest(mirrorURL string) (string, error) {
 	for i := range result {
 		if r.MatchString(bodyLines[i]) {
 			str := r.FindString(bodyLines[i])
-			trimstr := strings.Trim(str, "/\"") //remove '/' or '"' from /X.X.X/" or /X.X.X"
+			trimstr := strings.Trim(str, "/\"") // remove '/' or '"' from /X.X.X/" or /X.X.X"
 			return trimstr, nil
 		}
 	}
@@ -76,7 +76,7 @@ func getTFLatest(mirrorURL string) (string, error) {
 // getTFLatestImplicit :  Get the latest implicit terraform version given the hashicorp url
 func getTFLatestImplicit(mirrorURL string, preRelease bool, version string) (string, error) {
 	if preRelease {
-		//TODO: use getTFList() instead of getTFURLBody
+		// TODO: use getTFList() instead of getTFURLBody
 		body, error := getTFURLBody(mirrorURL)
 		if error != nil {
 			return "", error
@@ -91,13 +91,13 @@ func getTFLatestImplicit(mirrorURL string, preRelease bool, version string) (str
 		for i := range versions {
 			if r.MatchString(versions[i]) {
 				str := r.FindString(versions[i])
-				trimstr := strings.Trim(str, "/\"") //remove '/' or '"' from /X.X.X/" or /X.X.X"
+				trimstr := strings.Trim(str, "/\"") // remove '/' or '"' from /X.X.X/" or /X.X.X"
 				return trimstr, nil
 			}
 		}
 	} else if !preRelease {
 		listAll := false
-		tflist, _ := getTFList(mirrorURL, listAll) //get list of versions
+		tflist, _ := getTFList(mirrorURL, listAll) // get list of versions
 		version = fmt.Sprintf("~> %v", version)
 		semv, err := SemVerParser(&version, tflist)
 		if err != nil {
@@ -110,10 +110,9 @@ func getTFLatestImplicit(mirrorURL string, preRelease bool, version string) (str
 
 // getTFURLBody : Get list of terraform versions from hashicorp releases
 func getTFURLBody(mirrorURL string) (string, error) {
-
 	hasSlash := strings.HasSuffix(mirrorURL, "/")
 	if !hasSlash {
-		//if it does not have slash - append slash
+		// if it does not have slash - append slash
 		mirrorURL = fmt.Sprintf("%s/", mirrorURL)
 	}
 	resp, errURL := http.Get(mirrorURL)
@@ -184,7 +183,6 @@ func removeDuplicateVersions(elements []string) []string {
 // For example: 0.1. 2 = invalid
 */
 func validVersionFormat(version string) bool {
-
 	// Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
 	// Follow https://semver.org/spec/v1.0.0-beta.html
 	// Check regular expression at https://rubular.com/r/ju3PxbaSBALpJB
@@ -198,7 +196,6 @@ func validVersionFormat(version string) bool {
 // For example: 0.1.2 = invalid
 */
 func validMinorVersionFormat(version string) bool {
-
 	// Getting versions from body; should return match /X.X./ where X is a number
 	semverRegex := regexp.MustCompile(`^(\d+\.\d+)$`)
 
@@ -218,7 +215,7 @@ func ShowLatestImplicitVersion(requestedVersion, mirrorURL string, preRelease bo
 		if len(tfversion) > 0 {
 			fmt.Printf("%s\n", tfversion)
 		} else {
-			logger.Fatal("The provided terraform version does not exist.\n Try `tfswitch -l` to see all available versions")
+			logger.Fatal("Requested version does not exist.\n\tTry `tfswitch -l` to see all available versions")
 			os.Exit(1)
 		}
 	} else {

--- a/lib/param_parsing/parameters.go
+++ b/lib/param_parsing/parameters.go
@@ -56,7 +56,7 @@ func populateParams(params Params) Params {
 	getopt.StringVarLong(&params.ChDirPath, "chdir", 'c', "Switch to a different working directory before executing the given command. Ex: tfswitch --chdir terraform_project will run tfswitch in the terraform_project directory")
 	getopt.StringVarLong(&params.CustomBinaryPath, "bin", 'b', "Custom binary path. Ex: tfswitch -b "+lib.ConvertExecutableExt("/Users/username/bin/terraform"))
 	getopt.StringVarLong(&params.DefaultVersion, "default", 'd', "Default to this version in case no other versions could be detected. Ex: tfswitch --default 1.2.4")
-	getopt.BoolVarLong(&params.DryRun, "dry-run", 'r', "Only show what tfswitch would do. Don't download anything.")
+	getopt.BoolVarLong(&params.DryRun, "dry-run", 'r', "Only show what tfswitch would do. Don't download anything")
 	getopt.BoolVarLong(&params.HelpFlag, "help", 'h', "Displays help message")
 	getopt.StringVarLong(&params.InstallPath, "install", 'i', "Custom install path. Ex: tfswitch -i /Users/username. The binaries will be in the sub installDir directory e.g. /Users/username/"+lib.InstallDir)
 	getopt.BoolVarLong(&params.LatestFlag, "latest", 'u', "Get latest stable version")
@@ -74,7 +74,7 @@ func populateParams(params Params) Params {
 	// Parse the command line parameters to fetch stuff like chdir
 	getopt.Parse()
 
-	if !params.VersionFlag {
+	if !params.VersionFlag && !params.HelpFlag {
 		oldLogLevel := params.LogLevel
 		logger = lib.InitLogger(params.LogLevel)
 

--- a/lib/param_parsing/versiontf_test.go
+++ b/lib/param_parsing/versiontf_test.go
@@ -29,7 +29,7 @@ func TestGetVersionFromVersionsTF_impossible_constraints(t *testing.T) {
 	params.ChDirPath = "../../test-data/skip-integration-tests/test_versiontf_non_matching_constraints"
 	params.MirrorURL = lib.GetProductById("terraform").GetDefaultMirrorUrl()
 	params, err := GetVersionFromVersionsTF(params)
-	expectedError := "did not find version matching constraint: ~> 1.0.0, =1.0.5, <= 1.0.4"
+	expectedError := "Did not find version matching constraint: ~> 1.0.0, =1.0.5, <= 1.0.4"
 	if err == nil {
 		t.Errorf("Expected error '%s', got nil", expectedError)
 	} else {
@@ -68,7 +68,7 @@ func TestGetVersionFromVersionsTF_non_existent_constraint(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error got nil")
 	} else {
-		expected := "did not find version matching constraint: > 99999.0.0"
+		expected := "Did not find version matching constraint: > 99999.0.0"
 		if fmt.Sprint(err) != expected {
 			t.Errorf("Expected error %q, got %q", expected, err)
 		}

--- a/lib/semver.go
+++ b/lib/semver.go
@@ -10,25 +10,25 @@ import (
 // GetSemver : returns version that will be installed based on server constraint provided
 func GetSemver(tfconstraint string, mirrorURL string) (string, error) {
 	listAll := true
-	tflist, _ := getTFList(mirrorURL, listAll) //get list of versions
+	tflist, _ := getTFList(mirrorURL, listAll) // get list of versions
 	logger.Infof("Reading required version from constraint: %q", tfconstraint)
 	tfversion, err := SemVerParser(&tfconstraint, tflist)
 	return tfversion, err
 }
 
-// SemVerParser  : Goes through the list of terraform version, return a valid tf version for contraint provided
+// SemVerParser  : Goes through the list of versions, returns a valid version for contraint provided
 func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 	tfversion := ""
-	constraints, err := semver.NewConstraint(*tfconstraint) //NewConstraint returns a Constraints instance that a Version instance can be checked against
+	constraints, err := semver.NewConstraint(*tfconstraint) // NewConstraint returns a Constraints instance that a Version instance can be checked against
 	if err != nil {
-		return "", fmt.Errorf("error parsing constraint: %s", err)
+		return "", fmt.Errorf("Error parsing constraint: %s", err)
 	}
 	versions := make([]*semver.Version, len(tflist))
-	//put tfversion into semver object
+	// put tfversion into semver object
 	for i, tfvals := range tflist {
-		version, err := semver.NewVersion(tfvals) //NewVersion parses a given version and returns an instance of Version or an error if unable to parse the version.
+		version, err := semver.NewVersion(tfvals) // NewVersion parses a given version and returns an instance of Version or an error if unable to parse the version.
 		if err != nil {
-			return "", fmt.Errorf("error parsing constraint: %s", err)
+			return "", fmt.Errorf("Error parsing constraint: %s", err)
 		}
 		versions[i] = version
 	}
@@ -38,7 +38,7 @@ func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 	for _, element := range versions {
 		if constraints.Check(element) { // Validate a version against a constraint
 			tfversion = element.String()
-			if validVersionFormat(tfversion) { //check if version format is correct
+			if validVersionFormat(tfversion) { // check if version format is correct
 				logger.Infof("Matched version: %q", tfversion)
 				return tfversion, nil
 			} else {
@@ -47,15 +47,15 @@ func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("did not find version matching constraint: %s", *tfconstraint)
+	return "", fmt.Errorf("Did not find version matching constraint: %s", *tfconstraint)
 }
 
 // PrintInvalidTFVersion Print invalid TF version
 func PrintInvalidTFVersion() {
-	logger.Info("Version does not exist or invalid terraform version format.\n Format should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n For example, 0.11.7 and 0.11.9-beta1 are valid versions")
+	logger.Warn("Version does not exist or invalid terraform version format.\n\tFormat should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n\tFor example, 0.11.7 and 0.11.9-beta1 are valid versions")
 }
 
 // PrintInvalidMinorTFVersion Print invalid minor TF version
 func PrintInvalidMinorTFVersion() {
-	logger.Info("Invalid minor terraform version format.\n Format should be #.# where # are numbers. For example, 0.11 is valid version")
+	logger.Warn("Invalid minor terraform version format.\n\tFormat should be #.# where # are numbers. For example, 0.11 is valid version")
 }

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -126,7 +126,7 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 	if err == nil {
 		return fmt.Errorf("None of the installation directories exist: \"%s\". %s\n",
 			strings.Join(possibleInstallDirs, `", "`),
-			"Manually create one of them and try again.")
+			"Manually create one of them and try again")
 	}
 
 	return err

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -1,9 +1,9 @@
 package lib
 
 import (
-	"fmt"
-	"github.com/pborman/getopt"
 	"os"
+
+	"github.com/pborman/getopt"
 )
 
 // FileExistsAndIsNotDir checks if a file exists and is not a directory before we try using it to prevent further errors
@@ -23,7 +23,5 @@ func closeFileHandlers(handlers []*os.File) {
 }
 
 func UsageMessage() {
-	fmt.Print("\n\n")
 	getopt.PrintUsage(os.Stderr)
-	fmt.Println("Supply the terraform version as an argument, or choose from a menu")
 }

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		if version != "" {
 			fmt.Printf("Version: %s\n", version)
 		} else {
-			fmt.Println("Version not defined during build.")
+			fmt.Println("Version not defined during build")
 		}
 		os.Exit(0)
 	case parameters.HelpFlag:


### PR DESCRIPTION
* Drop trailing full stops in messages for consistency
* Capitalize messages
* Use tab instead of space to indent multiline messages
* `InstallProductVersion()`:
  * Drop pointless usage message
  * Improve error message by expanding word `args` to `Argument`
  * Use `product.GetName()` instead of hardcoded `terraform`
* Quit early when `--help` cmdline flag is supplied
* `PrintInvalidTFVersion()` print at Warn log level instead of Info
* `PrintInvalidMinorTFVersion()` print at Warn log level instead of Info
* `UsageMessage()` drop pointless blank lines and extraneous howto
* Code autoformatting in changed files (`golint`)