### PR TITLE
fix: Improve logging and fix installation bug

### DIFF
--- a/lib/files.go
+++ b/lib/files.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -201,23 +200,26 @@ func CheckDirHasTGBin(dir, prefix string) bool {
 // CheckDirExist : check if directory exist
 // dir=path to file
 // return bool
-func CheckDirExist(dir string) (fs.FileInfo, bool) {
-	fi, err := os.Stat(dir)
-
-	if os.IsNotExist(err) {
+func CheckDirExist(dir string) bool {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		logger.Debugf("Directory %q doesn't exist", dir)
-		return fi, false
+		return false
 	}
 
-	return fi, true
+	return true
 }
 
 // CheckIsDir: check if is directory
 // dir=path to file
 // return bool
-func CheckIsDir(dir fs.FileInfo) bool {
-	if !dir.IsDir() {
-		logger.Debugf("The %q is not a directory", dir.Name())
+func CheckIsDir(dir string) bool {
+	fi, err := os.Stat(dir)
+
+	if err != nil {
+		logger.Debugf("Error checking %q: %w", dir, err)
+		return false
+	} else if !fi.IsDir() {
+		logger.Debugf("The %q is not a directory", dir)
 		return false
 	}
 

--- a/lib/files.go
+++ b/lib/files.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -200,11 +201,26 @@ func CheckDirHasTGBin(dir, prefix string) bool {
 // CheckDirExist : check if directory exist
 // dir=path to file
 // return bool
-func CheckDirExist(dir string) bool {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+func CheckDirExist(dir string) (fs.FileInfo, bool) {
+	fi, err := os.Stat(dir)
+
+	if os.IsNotExist(err) {
 		logger.Debugf("Directory %q doesn't exist", dir)
+		return fi, false
+	}
+
+	return fi, true
+}
+
+// CheckIsDir: check if is directory
+// dir=path to file
+// return bool
+func CheckIsDir(dir fs.FileInfo) bool {
+	if !dir.IsDir() {
+		logger.Debugf("The %q is not a directory", dir.Name())
 		return false
 	}
+
 	return true
 }
 

--- a/lib/install.go
+++ b/lib/install.go
@@ -155,9 +155,9 @@ func ConvertExecutableExt(fpath string) string {
 // If not, create $HOME/bin. Ask users to add  $HOME/bin to $PATH and return $HOME/bin as install location
 // Deprecated: This function has been deprecated and will be removed in v2.0.0
 func installableBinLocation(product Product, userBinPath string) string {
-	homedir := GetHomeDirectory()            // get user's home directory
-	binDir := Path(userBinPath)              // get path directory from binary path
-	_, binPathExist := CheckDirExist(binDir) // the default is /usr/local/bin but users can provide custom bin locations
+	homedir := GetHomeDirectory()         // get user's home directory
+	binDir := Path(userBinPath)           // get path directory from binary path
+	binPathExist := CheckDirExist(binDir) // the default is /usr/local/bin but users can provide custom bin locations
 
 	if binPathExist { // if bin path exist - check if we can write to it
 
@@ -169,8 +169,7 @@ func installableBinLocation(product Product, userBinPath string) string {
 		// IF: "/usr/local/bin" or `custom bin path` provided by user is non-writable, (binPathWritable == false), we will attempt to install terraform at the ~/bin location. See ELSE
 		if !binPathWritable {
 			homeBinDir := filepath.Join(homedir, "bin")
-			_, homeBinExist := CheckDirExist(homeBinDir)
-			if !homeBinExist { // if ~/bin exist, install at ~/bin/terraform
+			if !CheckDirExist(homeBinDir) { // if ~/bin exist, install at ~/bin/terraform
 				logger.Noticef("Unable to write to %q", userBinPath)
 				logger.Infof("Creating bin directory at %q", homeBinDir)
 				createDirIfNotExist(homeBinDir) // create ~/bin

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -57,7 +57,7 @@ func InitLogger(logLevel string) *slog.Logger {
 		break
 	case "NOTICE":
 		h = NewStderrConsoleHandler(NoticeLogging)
-		formatter.SetTemplate(loggingTemplateDebug)
+		formatter.SetTemplate(loggingTemplate)
 		break
 	default:
 		h = NewStderrConsoleHandler(NormalLogging)

--- a/lib/param_parsing/parameters.go
+++ b/lib/param_parsing/parameters.go
@@ -2,8 +2,10 @@ package param_parsing
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/gookit/slog"
@@ -102,6 +104,7 @@ func populateParams(params Params) Params {
 		} else { // Use else as there is a warning that params maybe nil, as it does not see Fatalf as a break condition
 			if params.MirrorURL == "" {
 				params.MirrorURL = product.GetDefaultMirrorUrl()
+				logger.Debugf("Default mirror URL: %q", params.MirrorURL)
 			}
 
 			// Set default bin directory, if not configured
@@ -150,6 +153,7 @@ func populateParams(params Params) Params {
 			logger = lib.InitLogger(params.LogLevel)
 		}
 	}
+
 	// Parse again to overwrite anything that might by defined on the cli AND in any config file (CLI always wins)
 	getopt.Parse()
 	args := getopt.Args()
@@ -158,6 +162,22 @@ func populateParams(params Params) Params {
 		params.Version = args[0]
 	}
 
+	logger.Debugf("Resolved CPU architecture: %q", params.Arch)
+	if params.DryRun {
+		logger.Info("[DRY-RUN] No changes will be made")
+	} else {
+		logger.Debugf("Resolved dry-run: %q", strconv.FormatBool(params.DryRun))
+	}
+	if params.DefaultVersion != "" {
+		logger.Debugf("Resolved fallback version: %q", params.DefaultVersion)
+	}
+	logger.Debugf("Resolved installation path: %q", path.Join(params.InstallPath, lib.InstallDir))
+	logger.Debugf("Resolved installation target: %q", params.CustomBinaryPath)
+	logger.Debugf("Resolved installation version: %q", params.Version)
+	logger.Debugf("Resolved log level: %q", params.LogLevel)
+	logger.Debugf("Resolved mirror URL: %q", params.MirrorURL)
+	logger.Debugf("Resolved product name: %q", params.Product)
+	logger.Debugf("Resolved target directory: %q", params.ChDirPath)
 	return params
 }
 

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -27,29 +27,29 @@ func getParamsTOML(params Params) (Params, error) {
 			return params, errs
 		}
 
-		if viperParser.Get("arch") != nil {
-			params.Arch = os.ExpandEnv(viperParser.GetString("arch"))
-			logger.Debugf("Using \"arch\" from %q: %q", tomlPath, params.Arch)
+		if configKey := "arch"; viperParser.Get(configKey) != nil {
+			params.Arch = os.ExpandEnv(viperParser.GetString(configKey))
+			logger.Debugf("OS architecture (%q) from %q: %q", configKey, tomlPath, params.Arch)
 		}
-		if viperParser.Get("bin") != nil {
-			params.CustomBinaryPath = os.ExpandEnv(viperParser.GetString("bin"))
-			logger.Debugf("Using \"bin\" from %q: %q", tomlPath, params.CustomBinaryPath)
+		if configKey := "bin"; viperParser.Get(configKey) != nil {
+			params.CustomBinaryPath = os.ExpandEnv(viperParser.GetString(configKey))
+			logger.Debugf("Installation target (%q) from %q: %q", configKey, tomlPath, params.CustomBinaryPath)
 		}
-		if viperParser.Get("log-level") != nil {
-			params.LogLevel = viperParser.GetString("log-level")
-			logger.Debugf("Using \"log-level\" from %q: %q", tomlPath, params.LogLevel)
+		if configKey := "log-level"; viperParser.Get(configKey) != nil {
+			params.LogLevel = viperParser.GetString(configKey)
+			logger.Debugf("Logging level (%q) from %q: %q", configKey, tomlPath, params.LogLevel)
 		}
-		if viperParser.Get("version") != nil {
-			params.Version = viperParser.GetString("version")
-			logger.Debugf("Using \"version\" from %q: %q", tomlPath, params.Version)
+		if configKey := "version"; viperParser.Get(configKey) != nil {
+			params.Version = viperParser.GetString(configKey)
+			logger.Debugf("Installation version (%q) from %q: %q", configKey, tomlPath, params.Version)
 		}
-		if viperParser.Get("default-version") != nil {
-			params.DefaultVersion = viperParser.GetString("default-version")
-			logger.Debugf("Using \"default-version\" from %q: %q", tomlPath, params.DefaultVersion)
+		if configKey := "default-version"; viperParser.Get(configKey) != nil {
+			params.DefaultVersion = viperParser.GetString(configKey)
+			logger.Debugf("Fallback version (%q) from %q: %q", configKey, tomlPath, params.DefaultVersion)
 		}
 		if configKey := "product"; viperParser.Get(configKey) != nil {
 			params.Product = viperParser.GetString(configKey)
-			logger.Debugf("Using %q from %q: %q", configKey, tomlPath, params.Product)
+			logger.Debugf("Product name (%q) from %q: %q", configKey, tomlPath, params.Product)
 		}
 	}
 	return params, nil

--- a/lib/semver.go
+++ b/lib/semver.go
@@ -52,10 +52,10 @@ func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 
 // PrintInvalidTFVersion Print invalid TF version
 func PrintInvalidTFVersion() {
-	logger.Error("Version does not exist or invalid terraform version format.\n\tFormat should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n\tFor example, -1.11.7 and 0.11.9-beta1 are valid versions")
+	logger.Error("Version does not exist or invalid terraform version format.\n\tFormat should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n\tFor example, 1.11.7 and 0.11.9-beta1 are valid versions")
 }
 
 // PrintInvalidMinorTFVersion Print invalid minor TF version
 func PrintInvalidMinorTFVersion() {
-	logger.Error("Invalid minor terraform version format.\n\tFormat should be #.# where # are numbers. For example, -1.11 is valid version")
+	logger.Error("Invalid minor terraform version format.\n\tFormat should be #.# where # are numbers. For example, 1.11 is valid version")
 }

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -127,8 +127,7 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 		logger.Noticef("Attempting to install to %q directory (possible install location №%d)", dirPath, attempt)
 
 		// If directory does not exist, check if we should create it, otherwise skip
-		dirFI, dirExist := CheckDirExist(dirPath)
-		if !dirExist {
+		if !CheckDirExist(dirPath) {
 			logger.Warnf("Installation directory %q doesn't exist!", dirPath)
 			if installLocationsShouldCreate[location] {
 				logger.Infof("Creating %q directory", dirPath)
@@ -140,7 +139,7 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 			} else {
 				continue
 			}
-		} else if !CheckIsDir(dirFI) {
+		} else if !CheckIsDir(dirPath) {
 			logger.Warnf("The %q is not a directory!", dirPath)
 			continue
 		}


### PR DESCRIPTION
Fixes #555
Closes #558

* Add `CheckIsDir()` to check if the path is directory
* Improve logging when `dry-run` flag is passed
* Use regular logging format of `NOTICE` log level
* Add more logging messages of `DEBUG` log level
* Make TOML config parsing consistent
* Add more logging when installing symlink
* Don't print `PATH` export suggestion on Windows (#558)
* Fix bug on symlink installation: use array of possible installation
  locations to preserve order as maps are unordered (#555)