### PR TITLE
docs: Update CHANGELOG with `v1.4.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.4.2](https://github.com/warrensbox/terraform-switcher/tree/v1.4.2) - 2025-03-14
+
+[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.4.1...v1.4.2)
+
+### Added
+
+- fix: Improve logging and fix symlink installation issues [#559](https://github.com/warrensbox/terraform-switcher/pull/559) ([yermulnik](https://github.com/yermulnik))
+
+### Other
+
+- docs: Update CHANGELOG with `v1.4.2` [#565](https://github.com/warrensbox/terraform-switcher/pull/565) ([yermulnik](https://github.com/yermulnik))
+
 ## [v1.4.1](https://github.com/warrensbox/terraform-switcher/tree/v1.4.1) - 2025-03-05
 
 [Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.4.0...v1.4.1)


### PR DESCRIPTION
## [v1.4.2](https://github.com/warrensbox/terraform-switcher/tree/v1.4.2) - 2025-03-14

[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.4.1...v1.4.2)

### Added

- fix: Improve logging and fix symlink installation issues [#559](https://github.com/warrensbox/terraform-switcher/pull/559) ([yermulnik](https://github.com/yermulnik))

### Other

- docs: Update CHANGELOG with `v1.4.2` [#565](https://github.com/warrensbox/terraform-switcher/pull/565) ([yermulnik](https://github.com/yermulnik))