### PR TITLE
fix: reinstate env var expansion in `bin` and add the same for `install` TOML params

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -5,7 +5,6 @@ excluded_labels:
   - dependencies
 sections:
   added:
-    - enhancement
     - feature
     - new feature
   changed:
@@ -14,6 +13,7 @@ sections:
   fixed:
     - bug
     - bugfix
+    - enhancement
     - fix
     - fixed
 skip_entries_without_label: false

--- a/CHANGELOG.howto.md
+++ b/CHANGELOG.howto.md
@@ -12,7 +12,6 @@
        - dependencies
      sections:
        added:
-         - enhancement
          - feature
          - new feature
        changed:
@@ -21,6 +20,7 @@
        fixed:
          - bug
          - bugfix
+         - enhancement
          - fix
          - fixed
      skip_entries_without_label: false

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -101,6 +101,9 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 		t.Error("LogLevel Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
 
+	os.Unsetenv("BIN_DIR_FROM_TOML")
+	os.Unsetenv("INSTALL_DIR_FROM_TOML")
+
 	t.Cleanup(func() {
 		getopt.CommandLine = getopt.New()
 	})

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -43,6 +43,10 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 	t.Cleanup(func() {
 		getopt.CommandLine = getopt.New()
 	})
+
+	os.Setenv("BIN_DIR_FROM_TOML", "/usr/local/bin")
+	os.Setenv("INSTALL_DIR_FROM_TOML", "/tmp")
+
 	expected := "../../test-data/integration-tests/test_tfswitchtoml"
 	os.Args = []string{"cmd", "--chdir=" + expected}
 	params := Params{}
@@ -61,6 +65,12 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 		t.Error("CustomBinaryPath Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
 
+	expected = "/tmp"
+	actual = params.InstallPath
+	if actual != expected {
+		t.Error("InstallPath Param was not as expected. Actual: " + actual + ", Expected: " + expected)
+	}
+
 	expected = "amd64"
 	actual = params.Arch
 	if actual != expected {
@@ -73,11 +83,24 @@ func TestGetParameters_params_are_overridden_by_toml_file(t *testing.T) {
 		t.Error("Version Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
 
+	expected = "1.5.4"
+	actual = params.DefaultVersion
+	if actual != expected {
+		t.Error("DefaultVersion Param was not as expected. Actual: " + actual + ", Expected: " + expected)
+	}
+
 	expected = "opentofu"
 	actual = params.Product
 	if actual != expected {
 		t.Error("Product Param was not as expected. Actual: " + actual + ", Expected: " + expected)
 	}
+
+	expected = "NOTICE"
+	actual = params.LogLevel
+	if actual != expected {
+		t.Error("LogLevel Param was not as expected. Actual: " + actual + ", Expected: " + expected)
+	}
+
 	t.Cleanup(func() {
 		getopt.CommandLine = getopt.New()
 	})

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -60,9 +60,9 @@ func getParamsTOML(params Params) (Params, error) {
 				}
 				for _, envExpandableKey := range envExpandableKeys {
 					if toml == envExpandableKey {
-						logger.Debugf("Expanding environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
 						envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
 						configKeyValue = envExpandedConfigKeyValue
+						logger.Debugf("Expanded environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
 					}
 				}
 

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -54,16 +54,11 @@ func getParamsTOML(params Params) (Params, error) {
 			if viperParser.Get(toml) != nil {
 				configKeyValue := viperParser.GetString(toml)
 
-				envExpandableKeys := []string{
-					"bin",
-					"install",
-				}
-				for _, envExpandableKey := range envExpandableKeys {
-					if toml == envExpandableKey {
-						envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
-						logger.Debugf("Expanded environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
-						configKeyValue = envExpandedConfigKeyValue
-					}
+				switch toml {
+				case "bin", "install":
+					envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
+					logger.Debugf("Expanded environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
+					configKeyValue = envExpandedConfigKeyValue
 				}
 
 				logger.Debugf("%s (%q) from %q: %q", description, toml, tomlPath, configKeyValue)

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -61,8 +61,8 @@ func getParamsTOML(params Params) (Params, error) {
 				for _, envExpandableKey := range envExpandableKeys {
 					if toml == envExpandableKey {
 						envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
-						configKeyValue = envExpandedConfigKeyValue
 						logger.Debugf("Expanded environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
+						configKeyValue = envExpandedConfigKeyValue
 					}
 				}
 

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -1,6 +1,7 @@
 package param_parsing
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -52,6 +53,19 @@ func getParamsTOML(params Params) (Params, error) {
 			}
 			if viperParser.Get(toml) != nil {
 				configKeyValue := viperParser.GetString(toml)
+
+				envExpandableKeys := []string{
+					"bin",
+					"install",
+				}
+				for _, envExpandableKey := range envExpandableKeys {
+					if toml == envExpandableKey {
+						envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
+						logger.Debugf("Expanding environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
+						configKeyValue = envExpandedConfigKeyValue
+					}
+				}
+
 				logger.Debugf("%s (%q) from %q: %q", description, toml, tomlPath, configKeyValue)
 				if !paramKey.CanSet() {
 					logger.Warnf("Parameter %q cannot be set, skipping assignment from TOML key %q", param, toml)

--- a/lib/param_parsing/toml.go
+++ b/lib/param_parsing/toml.go
@@ -60,8 +60,8 @@ func getParamsTOML(params Params) (Params, error) {
 				}
 				for _, envExpandableKey := range envExpandableKeys {
 					if toml == envExpandableKey {
-						envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
 						logger.Debugf("Expanding environment variables in %q TOML key value (if any): %q -> %q", toml, configKeyValue, envExpandedConfigKeyValue)
+						envExpandedConfigKeyValue := os.ExpandEnv(configKeyValue)
 						configKeyValue = envExpandedConfigKeyValue
 					}
 				}

--- a/lib/param_parsing/toml_test.go
+++ b/lib/param_parsing/toml_test.go
@@ -1,6 +1,7 @@
 package param_parsing
 
 import (
+	"os"
 	"testing"
 
 	"github.com/warrensbox/terraform-switcher/lib"
@@ -15,6 +16,7 @@ func prepare() Params {
 
 func TestGetParamsTOML_BinaryPath(t *testing.T) {
 	expected := "/usr/local/bin/terraform_from_toml"
+	os.Setenv("BIN_DIR_FROM_TOML", "/usr/local/bin")
 	params := prepare()
 	params, err := getParamsTOML(params)
 	if err != nil {
@@ -27,6 +29,7 @@ func TestGetParamsTOML_BinaryPath(t *testing.T) {
 
 func TestGetParamsTOML_InstallPath(t *testing.T) {
 	expected := "/tmp"
+	os.Setenv("INSTALL_DIR_FROM_TOML", "/tmp")
 	params := prepare()
 	params, err := getParamsTOML(params)
 	if err != nil {

--- a/lib/param_parsing/toml_test.go
+++ b/lib/param_parsing/toml_test.go
@@ -25,6 +25,7 @@ func TestGetParamsTOML_BinaryPath(t *testing.T) {
 	if params.CustomBinaryPath != expected {
 		t.Errorf("BinaryPath not matching. Got %v, expected %v", params.CustomBinaryPath, expected)
 	}
+	os.Unsetenv("BIN_DIR_FROM_TOML")
 }
 
 func TestGetParamsTOML_InstallPath(t *testing.T) {
@@ -38,6 +39,7 @@ func TestGetParamsTOML_InstallPath(t *testing.T) {
 	if params.InstallPath != expected {
 		t.Errorf("InstallPath not matching. Got %q, expected %q", params.InstallPath, expected)
 	}
+	os.Unsetenv("INSTALL_DIR_FROM_TOML")
 }
 
 func TestGetParamsTOML_Version(t *testing.T) {

--- a/test-data/integration-tests/test_tfswitchtoml/.tfswitch.toml
+++ b/test-data/integration-tests/test_tfswitchtoml/.tfswitch.toml
@@ -1,6 +1,6 @@
 arch = "amd64"
-bin = "/usr/local/bin/terraform_from_toml"
-install = "/tmp"
+bin = "$BIN_DIR_FROM_TOML/terraform_from_toml"
+install = "$INSTALL_DIR_FROM_TOML"
 default-version = "1.5.4"
 log-level = "NOTICE"
 product = "opentofu"


### PR DESCRIPTION
* Reinstate historical behavior on Env var expansion for `bin` TOML key, which was inadvertently dropped in #566
* Add the same feature for `install` TOML key
* Update corresponding tests