### PR TITLE
chore: Fix release changelog entry format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@
 version: 2
 
 env:
-  - CGO_ENABLED=0 # Build statically linked binaries
+  - CGO_ENABLED=0  # Build statically linked binaries
 
 builds:
   -
@@ -124,6 +124,24 @@ changelog:
   # Default: 'git'
   use: github
 
+  # Format to use for commit formatting.
+  #
+  # Templates: allowed.
+  #
+  # Default:
+  #    if 'git': '{{ .SHA }} {{ .Message }}'
+  #   otherwise: '{{ .SHA }}: {{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }})'.
+  #
+  # Extra template fields:
+  # - `SHA`: the commit SHA1
+  # - `Message`: the first line of the commit message, otherwise known as commit subject
+  # - `AuthorName`: the author full name (considers mailmap if 'git')
+  # - `AuthorEmail`: the author email (considers mailmap if 'git')
+  # - `AuthorUsername`: github/gitlab/gitea username - not available if 'git'
+  #
+  # Usage with 'git': Since: v2.8.
+  format: "{{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }})"
+
   # Sorts the changelog by the commit's messages.
   # Could either be asc, desc or empty
   # Empty means 'no sorting', it'll use the output of `git log` as is.
@@ -157,7 +175,7 @@ changelog:
       regexp: "^.*?doc(s|umentation).*"
     - title: Go
       order: 3
-      regexp: "^.*?go: "
+      regexp: "^go: "
     - title: Others
       order: 999
 


### PR DESCRIPTION
Since recent change in Goreleaser, it sort of incorrectly crops SHA from changelog entries and we end up with a colon before each entry title. Update Goreleaser `changelog.format` value by dropping `{{ .SHA }}: ` altogether to try abd recity this issue.