### PR TITLE
chore(.github/linters/.golangci.yml): Sync config with super-linter

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,2 +1,46 @@
-run:
-  timeout: 5m
+# https://raw.githubusercontent.com/super-linter/super-linter/refs/heads/main/TEMPLATES/.golangci.yml
+# Ref https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+version: "2"
+linters:
+  enable:
+    - goconst
+    - gocritic
+    - gocyclo
+    - gosec
+    - govet
+    - revive
+    - unconvert
+  settings:
+    errcheck:
+      check-blank: true
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - goconst
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/lib/download.go
+++ b/lib/download.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -117,7 +117,7 @@ func setupTestDownloadServer(t *testing.T, downloadProductTestConfig *DownloadPr
 		zipWriter := zip.NewWriter(zipFileBuffer)
 
 		executableBytes := []byte("This is the main executable")
-		zipFileContentWriter, err := zipWriter.Create("myprod")
+		zipFileContentWriter, err := zipWriter.Create("myprod") //nolint:govet
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -140,7 +140,7 @@ func setupTestDownloadServer(t *testing.T, downloadProductTestConfig *DownloadPr
 	if downloadProductTestConfig.ZipFileChecksum == "" {
 		sha256HashWriter := sha256.New()
 		zipFileReadBuffer := new(bytes.Buffer)
-		_, err := zipFileReadBuffer.Write(downloadProductTestConfig.ZipFileContent)
+		_, err := zipFileReadBuffer.Write(downloadProductTestConfig.ZipFileContent) //nolint:govet
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/files.go
+++ b/lib/files.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (

--- a/lib/install.go
+++ b/lib/install.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (
@@ -246,8 +247,8 @@ func InstallLatestProductImplicitVersion(product Product, dryRun bool, requested
 	}
 	tfversion, err := getTFLatestImplicit(mirrorURL, preRelease, requestedVersion)
 	if err == nil && tfversion != "" && !dryRun {
-		if err := install(product, tfversion, customBinaryPath, installPath, mirrorURL, arch); err != nil {
-			return fmt.Errorf("Error installing %s version %q: %v", product.GetName(), tfversion, err)
+		if errInstall := install(product, tfversion, customBinaryPath, installPath, mirrorURL, arch); errInstall != nil {
+			return fmt.Errorf("Error installing %s version %q: %v", product.GetName(), tfversion, errInstall)
 		}
 		return nil
 	}

--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (
@@ -46,13 +47,13 @@ func getTFList(mirrorURL string, preRelease bool) ([]string, error) {
 		return nil, err
 	}
 
-	var tfVersionList tfVersionList
-	getVersionsFromBody(result, preRelease, &tfVersionList)
+	var tfVerList tfVersionList
+	getVersionsFromBody(result, preRelease, &tfVerList)
 
-	if len(tfVersionList.tflist) == 0 {
+	if len(tfVerList.tflist) == 0 {
 		logger.Errorf("Cannot get version list from mirror: %s", mirrorURL)
 	}
-	return tfVersionList.tflist, nil
+	return tfVerList.tflist, nil
 }
 
 // getTFLatest :  Get the latest terraform version given the hashicorp url

--- a/lib/lockfile.go
+++ b/lib/lockfile.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -388,7 +388,7 @@ func TestDryRunFlagOutput(t *testing.T) {
 		t.Fatalf("Unexpected failure: \"%v\", output: %q", err, string(out))
 	}
 
-	var re *regexp.Regexp = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+	re := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
 	outNoANSI := func(str string) string {
 		return re.ReplaceAllString(str, "")
 	}(string(out))

--- a/lib/semver.go
+++ b/lib/semver.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -1,3 +1,4 @@
+//nolint:staticcheck //ST1005: error strings should not be capitalized (staticcheck)
 package lib
 
 import (
@@ -159,8 +160,8 @@ func ChangeProductSymlink(product Product, binVersionPath string, userBinPath st
 		/* remove current symlink if exist */
 		if CheckSymlink(location.path) {
 			logger.Debugf("Clearing away symlink before re-creating it: %q", location.path)
-			if err := RemoveSymlink(location.path); err != nil {
-				return fmt.Errorf("Error removing symlink %q: %v", location.path, err)
+			if errRemoveSymlink := RemoveSymlink(location.path); errRemoveSymlink != nil {
+				return fmt.Errorf("Error removing symlink %q: %v", location.path, errRemoveSymlink)
 			}
 		}
 


### PR DESCRIPTION
This is to resolve linter failure:
```
  2025-05-26 07:36:17 [INFO]   Linting GO_MODULES items...
  Error: -26 07:36:18 [ERROR]   Found errors when linting GO_MODULES. Exit code: 1.
  2025-05-26 07:36:18 [INFO]   Stderr contents for GO_MODULES:
  ------
  Error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
  Failed executing command with error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
  ------
```

Additionally resolve errors found by `golangci-lint` with new config.