### PR TITLE
chore(Makefile): Add `govulncheck` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ version:
 
 .PHONY: vulncheck
 vulncheck:
-	@which govulncheck >/dev/null 2>&1 && govulncheck -show color ./... || echo "govulncheck not found, skipping vulnerability check"
+	@command -v govulncheck >/dev/null 2>&1 && govulncheck -show color ./... || echo "govulncheck not found, skipping vulnerability check"
 
 .PHONY: vulncheck-verbose
 vulncheck-verbose:
-	@which govulncheck >/dev/null 2>&1 && govulncheck -show traces,color,version,verbose ./... || echo "govulncheck not found, skipping vulnerability check"
+	@command -v govulncheck >/dev/null 2>&1 && govulncheck -show traces,color,version,verbose ./... || echo "govulncheck not found, skipping vulnerability check"
 
 .PHONY: install
 install: $(EXE)


### PR DESCRIPTION
Update `Makefile` by adding `govulncheck` target and run it automatically as part of `test` target.

Refs:
- https://go.dev/blog/vuln
- https://go.dev/doc/tutorial/govulncheck
- https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
- https://github.com/golang/vuln