### PR TITLE
feat: Support falling back to Terraform for pre-1.6 releases

### DIFF
--- a/lib/param_parsing/versiontf.go
+++ b/lib/param_parsing/versiontf.go
@@ -42,7 +42,7 @@ func GetVersionFromVersionsTF(params Params) (Params, error) {
 	requiredVersions := module.RequiredCore
 
 	for key := range requiredVersions {
-		// Check if the version contraint is valid
+		// Check if the version constraint is valid
 		constraint, constraintErr := semver.NewConstraint(requiredVersions[key])
 		if constraintErr != nil {
 			logger.Errorf("Invalid version constraint found: %q", requiredVersions[key])
@@ -73,5 +73,5 @@ func isTerraformModule(params Params) bool {
 	if len(module.RequiredCore) == 0 {
 		logger.Debugf("No required version constraints defined by Terraform module at %q", params.ChDirPath)
 	}
-	return err == nil && len(module.RequiredCore) > 0
+	return len(module.RequiredCore) > 0
 }

--- a/lib/param_parsing/versiontf_test.go
+++ b/lib/param_parsing/versiontf_test.go
@@ -33,10 +33,70 @@ func TestGetVersionFromVersionsTF_matches_version(t *testing.T) {
 	}
 }
 
+// This test ensures we do fall back to FOSS Terraform when asked for versions
+// prior to 1.6.0, and that the version is parsed correctly when doing so.
+func TestGetVersionFromVersionsTF_fossFallback_matches_product(t *testing.T) {
+	logger = lib.InitLogger("DEBUG")
+	var params Params
+	var getVerErr error
+	params = initParams(params)
+	params.Product = "opentofu"
+	params.FossFallback = true
+	params.ProductEntity = lib.GetProductById(params.Product)
+	params.CustomBinaryPath = "/tmp/tofu"
+	params.ChDirPath = "../../test-data/integration-tests/test_versiontf"
+	params.MirrorURL = params.ProductEntity.GetDefaultMirrorUrl()
+	params, getVerErr = GetVersionFromVersionsTF(params)
+	if getVerErr != nil {
+		t.Errorf("Error getting version from Terraform module: %v", getVerErr)
+	}
+	expected := "terraform"
+	if params.Product != expected {
+		t.Errorf("Error falling back to FOSS Terraform, product is not terraform, but %s", params.Product)
+	}
+	v1, v1Err := version.NewVersion("1.0.5")
+	if v1Err != nil {
+		t.Errorf("Error parsing v1 version: %v", v1Err)
+	}
+	actualVersion, actualVersionErr := version.NewVersion(params.Version)
+	if actualVersionErr != nil {
+		t.Errorf("Error parsing actualVersion version: %v", actualVersionErr)
+	}
+	if !actualVersion.Equal(v1) {
+		t.Errorf("Determined version is not 1.0.5, but %s", params.Version)
+	}
+}
+
+// This test ensures we don't fall back to Terraform for versions on or after 1.6.0
+func TestGetVersionFromVersionsTF_fossFallback_only_for_foss_versions(t *testing.T) {
+	logger = lib.InitLogger("DEBUG")
+	var params Params
+	params = initParams(params)
+	params.Product = "opentofu"
+	params.FossFallback = true
+	params.ProductEntity = lib.GetProductById(params.Product)
+	params.CustomBinaryPath = "/tmp/tofu"
+	params.ChDirPath = "../../test-data/integration-tests/test_versiontf_foss"
+	params.MirrorURL = params.ProductEntity.GetDefaultMirrorUrl()
+	params, err := GetVersionFromVersionsTF(params)
+  // expectedError := "Error getting version from OpenTofu module: Did not find version matching constraint: =1.6.6"
+	expectedError := "Did not find version matching constraint: =1.6.6"
+	if err == nil {
+		t.Errorf("Expected error '%s', got nil", expectedError)
+	} else {
+		if err.Error() == expectedError {
+			t.Logf("Got expected error '%s'", err)
+		} else {
+			t.Errorf("Got unexpected error '%s'", err)
+		}
+	}
+}
+
 func TestGetVersionFromVersionsTF_impossible_constraints(t *testing.T) {
 	logger = lib.InitLogger("DEBUG")
 	var params Params
 	params = initParams(params)
+	params.ProductEntity = lib.GetProductById("terraform")
 	params.ChDirPath = "../../test-data/skip-integration-tests/test_versiontf_non_matching_constraints"
 	params.MirrorURL = lib.GetProductById("terraform").GetDefaultMirrorUrl()
 	params, err := GetVersionFromVersionsTF(params)
@@ -73,6 +133,7 @@ func TestGetVersionFromVersionsTF_non_existent_constraint(t *testing.T) {
 	logger = lib.InitLogger("DEBUG")
 	var params Params
 	params = initParams(params)
+	params.ProductEntity = lib.GetProductById("terraform")
 	params.ChDirPath = "../../test-data/skip-integration-tests/test_versiontf_non_existent"
 	params.MirrorURL = lib.GetProductById("terraform").GetDefaultMirrorUrl()
 	params, err := GetVersionFromVersionsTF(params)

--- a/lib/semver.go
+++ b/lib/semver.go
@@ -20,7 +20,7 @@ func GetSemver(tfconstraint string, mirrorURL string) (string, error) {
 	return tfversion, err
 }
 
-// SemVerParser  : Goes through the list of versions, returns a valid version for contraint provided
+// SemVerParser  : Goes through the list of versions, returns a valid version for constraint provided
 func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 	tfversion := ""
 	constraints, err := semver.NewConstraint(*tfconstraint) // NewConstraint returns a Constraints instance that a Version instance can be checked against

--- a/lib/semver.go
+++ b/lib/semver.go
@@ -53,6 +53,25 @@ func SemVerParser(tfconstraint *string, tflist []string) (string, error) {
 	return "", fmt.Errorf("Did not find version matching constraint: %s", *tfconstraint)
 }
 
+func SemVerCheckFoss(tfversion string) (bool, error) {
+	version, err := semver.NewVersion(tfversion)
+	if err != nil {
+		return false, fmt.Errorf("Error parsing version: %s", err)
+	}
+
+	constraint, err := semver.NewConstraint("<1.6.0")
+	if err != nil {
+		return false, fmt.Errorf("Error parsing FOSS constraint: %s", err)
+	}
+
+	if constraint.Check(version) {
+		logger.Infof("Terraform %s is a FOSS licensed release.", tfversion)
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // PrintInvalidTFVersion Print invalid TF version
 func PrintInvalidTFVersion() {
 	logger.Error("Version does not exist or invalid terraform version format.\n\tFormat should be #.#.# or #.#.#-@# where # are numbers and @ are word characters.\n\tFor example, 1.11.7 and 0.11.9-beta1 are valid versions")

--- a/lib/semver_test.go
+++ b/lib/semver_test.go
@@ -98,3 +98,32 @@ func TestSemverParserCase5(t *testing.T) {
 		t.Errorf("This is unexpected. Parsing failed. Expected: %q", expected)
 	}
 }
+
+func TestSemverCheckFoss(t *testing.T) {
+	tests := map[string]struct {
+		version string
+		expected   bool
+	}{
+		"FOSS": {
+			version: "1.5.1",
+			expected: true,
+		},
+		"BSL": {
+			version: "1.7.1",
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := lib.SemVerCheckFoss(test.version)
+			if err != nil {
+				t.Errorf("Error checking for Foss licensed version %q: %v", test.version, err)
+			}
+			if actual != test.expected {
+				t.Errorf("%s: Version %q returned %v. Expected: %v", name, test.version, actual, test.expected)
+			}
+		})
+	}
+}
+

--- a/test-data/integration-tests/test_versiontf_foss/version.tf
+++ b/test-data/integration-tests/test_versiontf_foss/version.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "=1.6.6"
+}


### PR DESCRIPTION

This adds an option to automatically fall back to using Terraform when the version required from a terraform module is older than 1.6.0. This will aid teams working across multiple repositories or monorepos that have modules that haven't yet been upgraded.

I only implemented the fallback for versiontf handling, as I expect that is the place it will most be needed.