### PR TITLE
feat: Add KeyBase as fallback source of Hashicorp's public PGP-key

### DIFF
--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -218,7 +218,7 @@ func TestDownloadProductFromURL(t *testing.T) {
 			ExecutableName: "myprod",
 			ArchivePrefix:  "my_product_download_",
 			PublicKeyId:    downloadProductTestConfig.GpgFingerprint,
-			PublicKeyUrl:   mockServer.URL + "/testproduct/gpg-key.txt",
+			PublicKeyURLs:  []string{mockServer.URL + "/testproduct/gpg-key.txt"},
 		},
 	}
 
@@ -256,7 +256,7 @@ func TestDownloadProductFromURL_invalid_checksum(t *testing.T) {
 			ExecutableName: "myprod",
 			ArchivePrefix:  "my_product_download_",
 			PublicKeyId:    downloadProductTestConfig.GpgFingerprint,
-			PublicKeyUrl:   mockServer.URL + "/testproduct/gpg-key.txt",
+			PublicKeyURLs:  []string{mockServer.URL + "/testproduct/gpg-key.txt"},
 		},
 	}
 
@@ -293,7 +293,7 @@ func TestDownloadProductFromURL_zip_file_not_present_in_checksum(t *testing.T) {
 			ExecutableName: "myprod",
 			ArchivePrefix:  "my_product_download_",
 			PublicKeyId:    downloadProductTestConfig.GpgFingerprint,
-			PublicKeyUrl:   mockServer.URL + "/testproduct/gpg-key.txt",
+			PublicKeyURLs:  []string{mockServer.URL + "/testproduct/gpg-key.txt"},
 		},
 	}
 
@@ -328,7 +328,7 @@ func TestDownloadProductFromURL_unable_to_download_public_key(t *testing.T) {
 			ExecutableName: "myprod",
 			ArchivePrefix:  "my_product_download_",
 			PublicKeyId:    downloadProductTestConfig.GpgFingerprint,
-			PublicKeyUrl:   mockServer.URL + "/testproduct/invalid-public-key",
+			PublicKeyURLs:  []string{mockServer.URL + "/testproduct/invalid-public-key"},
 		},
 	}
 
@@ -366,7 +366,7 @@ func TestDownloadProductFromURL_invalid_public_key(t *testing.T) {
 			ExecutableName: "myprod",
 			ArchivePrefix:  "my_product_download_",
 			PublicKeyId:    downloadProductTestConfig.GpgFingerprint,
-			PublicKeyUrl:   mockServer.URL + "/testproduct/gpg-key.txt",
+			PublicKeyURLs:  []string{mockServer.URL + "/testproduct/gpg-key.txt"},
 		},
 	}
 

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -87,7 +87,9 @@ func LogLevels() []string {
 		levels = append(levels, logLevels.Field(fieldNum).Name)
 	}
 
-	slices.Sort(levels) // Sort the result as we use it in output messages
+	// Preserve the order of log levels as defined in `loggingLevels` struct
+	// to make clear the order of verbosity 06-Sep-2025
+	// slices.Sort(levels) // Sort the result as we use it in output messages
 	return levels
 }
 

--- a/lib/param_parsing/parameters.go
+++ b/lib/param_parsing/parameters.go
@@ -85,7 +85,7 @@ func populateParams(params Params) Params {
 	getopt.StringVarLong(&params.InstallPath, "install", 'i', fmt.Sprintf("Custom install path. Ex: `tfswitch -i /Users/username`. The binaries will be in the sub installDir directory e.g. `/Users/username/%s`", lib.InstallDir))
 	getopt.StringVarLong(&params.LatestPre, "latest-pre", 'p', "Latest pre-release implicit version. Ex: `tfswitch --latest-pre 0.13` downloads 0.13.0-rc1 (latest)")
 	getopt.StringVarLong(&params.LatestStable, "latest-stable", 's', "Latest implicit version based on a constraint. Ex: `tfswitch --latest-stable 0.13.0` downloads 0.13.7 and 0.13 downloads 0.15.5 (latest)")
-	getopt.StringVarLong(&params.LogLevel, "log-level", 'g', fmt.Sprintf("Set tfswitch logging level. One of: %s. Use `OFF` to disable (suppress) logging", strings.Join(lib.LogLevels(), ", ")))
+	getopt.StringVarLong(&params.LogLevel, "log-level", 'g', fmt.Sprintf("Set tfswitch logging level. One of (in the order of increasing level of verbosity): %s. Use `OFF` to disable (suppress) logging", strings.Join(lib.LogLevels(), ", ")))
 	getopt.StringVarLong(&params.MirrorURL, "mirror", 'm', fmt.Sprintf("Install from a remote API other than the default.\nDefault (based on value of `--product`):\n  - %s", strings.Join(defaultMirrors, "\n  - ")))
 	getopt.StringVarLong(&params.ShowLatestPre, "show-latest-pre", 'P', "Show latest pre-release implicit version. Ex: `tfswitch --show-latest-pre 0.13` prints 0.13.0-rc1 (latest)")
 	getopt.StringVarLong(&params.ShowLatestStable, "show-latest-stable", 'S', "Show latest implicit version. Ex: `tfswitch --show-latest-stable 0.13` prints 0.13.7 (latest)")

--- a/lib/product.go
+++ b/lib/product.go
@@ -9,7 +9,6 @@ import (
 const legacyProductId = "terraform"
 
 // nolint:revive // FIXME: var-naming: struct field PublicKeyId should be PublicKeyID (revive)
-// nolint:revive // FIXME: var-naming: struct field PublicKeyUrl should be PublicKeyURL (revive)
 type ProductDetails struct {
 	ID                    string
 	Name                  string
@@ -19,7 +18,7 @@ type ProductDetails struct {
 	ExecutableName        string
 	ArchivePrefix         string
 	PublicKeyId           string
-	PublicKeyUrl          string
+	PublicKeyURLs         []string
 }
 
 type TerraformProduct struct {
@@ -33,7 +32,6 @@ type OpenTofuProduct struct {
 // nolint:revive // FIXME: var-naming: method GetDefaultMirrorUrl should be GetDefaultMirrorURL (revive)
 // nolint:revive // FIXME: var-naming: method GetArtifactUrl should be GetArtifactURL (revive)
 // nolint:revive // FIXME: var-naming: method GetPublicKeyId should be GetPublicKeyID (revive)
-// nolint:revive // FIXME: var-naming: method GetPublicKeyUrl should be GetPublicKeyURL (revive)
 type Product interface {
 	GetId() string
 	GetName() string
@@ -42,7 +40,7 @@ type Product interface {
 	GetExecutableName() string
 	GetArchivePrefix() string
 	GetPublicKeyId() string
-	GetPublicKeyUrl() string
+	GetPublicKeyURLs() []string
 	GetShaSignatureSuffix() string
 	GetArtifactUrl(mirrorURL string, version string) string
 	GetRecentVersionProduct(recentFile *RecentFile) []string
@@ -87,9 +85,8 @@ func (p TerraformProduct) GetPublicKeyId() string {
 	return p.PublicKeyId
 }
 
-// nolint:revive // FIXME: var-naming: method GetPublicKeyUrl should be GetPublicKeyURL (revive)
-func (p TerraformProduct) GetPublicKeyUrl() string {
-	return p.PublicKeyUrl
+func (p TerraformProduct) GetPublicKeyURLs() []string {
+	return p.PublicKeyURLs
 }
 
 func (p TerraformProduct) GetShaSignatureSuffix() string {
@@ -142,9 +139,8 @@ func (p OpenTofuProduct) GetPublicKeyId() string {
 	return p.PublicKeyId
 }
 
-// nolint:revive // FIXME: var-naming: method GetPublicKeyUrl should be GetPublicKeyURL (revive)
-func (p OpenTofuProduct) GetPublicKeyUrl() string {
-	return p.PublicKeyUrl
+func (p OpenTofuProduct) GetPublicKeyURLs() []string {
+	return p.PublicKeyURLs
 }
 
 func (p OpenTofuProduct) GetShaSignatureSuffix() string {
@@ -170,7 +166,7 @@ var products = []Product{
 			ExecutableName: "terraform",
 			ArchivePrefix:  "terraform_",
 			PublicKeyId:    "72D7468F",
-			PublicKeyUrl:   "https://www.hashicorp.com/.well-known/pgp-key.txt",
+			PublicKeyURLs:  []string{"https://www.hashicorp.com/.well-known/pgp-key.txt", "https://keybase.io/hashicorp/pgp_keys.asc"},
 		},
 	},
 	OpenTofuProduct{
@@ -183,7 +179,7 @@ var products = []Product{
 			ExecutableName:        "tofu",
 			ArchivePrefix:         "tofu_",
 			PublicKeyId:           "0C0AF313E5FD9F80",
-			PublicKeyUrl:          "https://get.opentofu.org/opentofu.asc",
+			PublicKeyURLs:         []string{"https://get.opentofu.org/opentofu.asc"},
 		},
 	},
 }

--- a/lib/product_test.go
+++ b/lib/product_test.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -105,11 +107,12 @@ func Test_GetPublicKeyId_Terraform(t *testing.T) {
 	}
 }
 
-func Test_GetPublicKeyUrl_Terraform(t *testing.T) {
+func Test_GetPublicKeyURLs_Terraform(t *testing.T) {
 	product := GetProductById("terraform")
-	actual := product.GetPublicKeyUrl()
-	if expected := "https://www.hashicorp.com/.well-known/pgp-key.txt"; actual != expected {
-		t.Errorf("Product GetPublicKeyUrl does not match expected ID. Expected: %q, actual: %q", expected, actual)
+	expected := []string{"https://www.hashicorp.com/.well-known/pgp-key.txt", "https://keybase.io/hashicorp/pgp_keys.asc"}
+	actual := product.GetPublicKeyURLs()
+	if !slices.Equal(expected, actual) {
+		t.Errorf("Product GetPublicKeyURLs does not match expected ID. Expected: %q, actual: %q", strings.Join(expected, ","), strings.Join(actual, ","))
 	}
 }
 
@@ -223,9 +226,10 @@ func Test_GetPublicKeyId_OpenTofu(t *testing.T) {
 
 func Test_GetPublicKeyUrl_OpenTofu(t *testing.T) {
 	product := GetProductById("opentofu")
-	actual := product.GetPublicKeyUrl()
-	if expected := "https://get.opentofu.org/opentofu.asc"; actual != expected {
-		t.Errorf("Product GetPublicKeyUrl does not match expected ID. Expected: %q, actual: %q", expected, actual)
+	expected := []string{"https://get.opentofu.org/opentofu.asc"}
+	actual := product.GetPublicKeyURLs()
+	if !slices.Equal(expected, actual) {
+		t.Errorf("Product GetPublicKeyURLs does not match expected ID. Expected: %q, actual: %q", strings.Join(expected, ","), strings.Join(actual, ","))
 	}
 }
 


### PR DESCRIPTION
- Add https://keybase.io/hashicorp/pgp_keys.asc as fallback source of Hashicorp's public PGP-key
- Allow multiple sources for Product's public PGP-key
- (unrelated) Preserve ordering of `LogLevels` in output messages to make clear the order of increasing level of verbosity (try to improve UX)

Relates to:
- #540
- #621