### PR TITLE
docs: Update CHANGELOG with `v1.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.6.0](https://github.com/warrensbox/terraform-switcher/tree/v1.6.0) - 2025-09-07
+
+[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.5.1...v1.6.0)
+
+### Added
+
+- feat: Add KeyBase as fallback source of Hashicorp's public PGP-key [#624](https://github.com/warrensbox/terraform-switcher/pull/624) ([yermulnik](https://github.com/yermulnik))
+
+### Fixed
+
+- fix: [release workflow] `mkdocs gh-deploy` requires creds to persist [#623](https://github.com/warrensbox/terraform-switcher/pull/623) ([yermulnik](https://github.com/yermulnik))
+
+### Other
+
+- docs: Update CHANGELOG with `v1.6.0` [#622](https://github.com/warrensbox/terraform-switcher/pull/625) ([yermulnik](https://github.com/yermulnik))
+
 ## [v1.5.1](https://github.com/warrensbox/terraform-switcher/tree/v1.5.1) - 2025-09-06
 
 [Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.5.0...v1.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
-- feat: Add KeyBase as fallback source of Hashicorp's public PGP-key [#624](https://github.com/warrensbox/terraform-switcher/pull/624) ([yermulnik](https://github.com/yermulnik))
+- feat: Add Keybase as fallback source of Hashicorp's public PGP-key [#624](https://github.com/warrensbox/terraform-switcher/pull/624) ([yermulnik](https://github.com/yermulnik))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Other
 
-- docs: Update CHANGELOG with `v1.6.0` [#622](https://github.com/warrensbox/terraform-switcher/pull/625) ([yermulnik](https://github.com/yermulnik))
+- docs: Update CHANGELOG with `v1.6.0` [#625](https://github.com/warrensbox/terraform-switcher/pull/625) ([yermulnik](https://github.com/yermulnik))
 
 ## [v1.5.1](https://github.com/warrensbox/terraform-switcher/tree/v1.5.1) - 2025-09-06
 


### PR DESCRIPTION
### Added

- feat: Add KeyBase as fallback source of Hashicorp's public PGP-key [#624](https://github.com/warrensbox/terraform-switcher/pull/624) ([yermulnik](https://github.com/yermulnik))

### Fixed

- fix: [release workflow] `mkdocs gh-deploy` requires creds to persist [#623](https://github.com/warrensbox/terraform-switcher/pull/623) ([yermulnik](https://github.com/yermulnik))

### Other

- docs: Update CHANGELOG with `v1.6.0` [#625](https://github.com/warrensbox/terraform-switcher/pull/625) ([yermulnik](https://github.com/yermulnik))