### PR TITLE
docs: Update CHANGELOG with `v1.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 [Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.8.0...v1.9.0)
 
-### Fixed
+### Added
 
 - feat(terragrunt): Support `root.hcl` and custom file name [#644](https://github.com/warrensbox/terraform-switcher/pull/644) ([yermulnik](https://github.com/yermulnik))
 


### PR DESCRIPTION
## [v1.9.0](https://github.com/warrensbox/terraform-switcher/tree/v1.9.0) - 2025-10-31

[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.8.0...v1.9.0)

### Added

- feat(terragrunt): Support `root.hcl` and custom file name [#644](https://github.com/warrensbox/terraform-switcher/pull/644) ([yermulnik](https://github.com/yermulnik))

### Other

- docs: Update CHANGELOG with `v1.9.0` [#647](https://github.com/warrensbox/terraform-switcher/pull/647) ([yermulnik](https://github.com/yermulnik))