### PR TITLE
docs: Update CHANGELOG with `v1.11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Other
 
-- docs: Update CHANGELOG with `v1.11.0` [#672](https://github.com/warrensbox/terraform-switcher/pull/672) ([yermulnik](https://github.com/yermulnik))
+- docs: Update CHANGELOG with `v1.11.0` [#674](https://github.com/warrensbox/terraform-switcher/pull/674) ([yermulnik](https://github.com/yermulnik))
 
 ## [v1.10.0](https://github.com/warrensbox/terraform-switcher/tree/v1.10.0) - 2025-11-26
 


### PR DESCRIPTION
## [v1.11.0](https://github.com/warrensbox/terraform-switcher/tree/v1.11.0) - 2025-12-13

[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.10.0...v1.11.0)

### Fixed

- fix: Fail fast if `chdir` directory is not readable [#671](https://github.com/warrensbox/terraform-switcher/pull/671) ([yermulnik](https://github.com/yermulnik))
- fix: Don't PromptUI in non-interactive terminal [#669](https://github.com/warrensbox/terraform-switcher/pull/669) ([yermulnik](https://github.com/yermulnik))

### Other

- docs: Update CHANGELOG with `v1.11.0` [#674](https://github.com/warrensbox/terraform-switcher/pull/674) ([yermulnik](https://github.com/yermulnik))