### PR TITLE
chore(multi-labeler): Remove `pull_request` target from `multi-labeler` workflow

### DIFF
--- a/.github/workflows/multi-labeler.yml
+++ b/.github/workflows/multi-labeler.yml
@@ -7,7 +7,7 @@ on:
     # types list ordering is based on the order from
     # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
     types: [opened, edited, reopened, synchronize, ready_for_review]
-    branches: [master, main]
+    branches: [master, main] # zizmor: ignore[dangerous-triggers]
 
 permissions:
   # Setting up permissions in the workflow to limit the scope of what it can do. Optional!


### PR DESCRIPTION
Removal ensures PRs from forked repos ain't failing `multi-labeler` workflow as `pull_request` trigger type has too limited access.

The drawback is that the updated workflow file can't be tested within the same branch as it is called from base branch instead.

See pretty clear explanation at
[actions/labeler](https://github.com/actions/labeler#notes-regarding-pull_request_target-event) repo's README.

Also, while here, add `reopened` PR type to workflow triggers.