### PR TITLE
docs: Update CHANGELOG with `v1.12.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.12.0](https://github.com/warrensbox/terraform-switcher/tree/v1.12.0) - 2025-12-14
+
+[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.11.0...v1.12.0)
+
+### Added
+
+- feat(shell-completion): fish shell completion [#665](https://github.com/warrensbox/terraform-switcher/pull/665) ([marcaurele](https://github.com/marcaurele))
+
+### Other
+
+- docs: Update CHANGELOG with `v1.12.0` [#676](https://github.com/warrensbox/terraform-switcher/pull/676) ([yermulnik](https://github.com/yermulnik))
+
 ## [v1.11.0](https://github.com/warrensbox/terraform-switcher/tree/v1.11.0) - 2025-12-13
 
 [Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.10.0...v1.11.0)


### PR DESCRIPTION
## [v1.12.0](https://github.com/warrensbox/terraform-switcher/tree/v1.12.0) - 2025-12-14

[Full Changelog](https://github.com/warrensbox/terraform-switcher/compare/v1.11.0...v1.12.0)

### Added

- feat(shell-completion): fish shell completion [#665](https://github.com/warrensbox/terraform-switcher/pull/665) ([marcaurele](https://github.com/marcaurele))

### Other

- docs: Update CHANGELOG with `v1.12.0` [#676](https://github.com/warrensbox/terraform-switcher/pull/676) ([yermulnik](https://github.com/yermulnik))