### PR TITLE
fix: Verify checksum signature against every PGP key in the public key file

### DIFF
--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -80,7 +80,7 @@ func parsePublicKeys(armored string) ([]*crypto.Key, error) {
 	// preserves the mandatory blank line between the marker/headers and
 	// the base64 payload that RFC 4880 armor requires.
 	parts := strings.Split(armored, pgpPublicKeyBegin)
-	keys := make([]*crypto.Key, 0, len(parts))
+	keys := make([]*crypto.Key, 0, len(parts)-1)
 	for i, part := range parts {
 		if i == 0 {
 			continue

--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -122,6 +122,10 @@ func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFil
 	}
 
 	verifyBuilder := crypto.PGP().Verify()
+	// Parse every armored block from the key file and register each parsed key
+	// with verify handle builder. Successive VerificationKey() calls append
+	// to the builder's internal keyring, and the key matching the signature's
+	// KeyID is picked automatically.
 	for key := range slices.Values(keys) {
 		verifyBuilder = verifyBuilder.VerificationKey(key)
 	}

--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,11 @@ import (
 
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
 )
+
+// pgpPublicKeyBegin is the ASCII armor marker that delimits every public
+// key block in a concatenated armored file (such as HashiCorp's
+// pgp-key.txt, which publishes more than one key around rotations).
+const pgpPublicKeyBegin = "-----BEGIN PGP PUBLIC KEY BLOCK-----"
 
 // getChecksumFromFile Extract the checksum from the signature file
 func getChecksumFromHashFile(signatureFilePath string, terraformFileName string) (string, error) {
@@ -58,6 +64,40 @@ func checkChecksumMatches(hashFile string, targetFile *os.File) bool {
 	return true
 }
 
+// parsePublicKeys extracts every armored PGP public key from the given
+// blob. HashiCorp's pgp-key.txt contains more than one key around key
+// rotations, and the key that signed a release may not be the first
+// block. crypto.NewKeyFromArmored refuses multi-entity input, so the
+// caller must feed it one armored block at a time.
+//
+// Blocks that fail to parse are logged at Debug and skipped; the
+// function returns an error only when no usable keys remain.
+func parsePublicKeys(armored string) ([]*crypto.Key, error) {
+	// strings.Split leaves the text preceding the first BEGIN marker in
+	// parts[0] (always non-key content); each subsequent entry is the
+	// body of one block. Re-prepending the marker rather than trimming
+	// preserves the mandatory blank line between the marker/headers and
+	// the base64 payload that RFC 4880 armor requires.
+	parts := strings.Split(armored, pgpPublicKeyBegin)
+	keys := make([]*crypto.Key, 0, len(parts))
+	for i, part := range parts {
+		if i == 0 {
+			continue
+		}
+		block := pgpPublicKeyBegin + part
+		key, err := crypto.NewKeyFromArmored(block)
+		if err != nil {
+			logger.Debugf("Skipping unparseable PGP public key block: %v", err)
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("no parseable PGP public keys found in key file")
+	}
+	return keys, nil
+}
+
 // checkSignatureOfChecksums This will verify the signature of the file containing the hash sums
 func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFile *os.File) bool {
 	var fileHandlersToClose []*os.File
@@ -74,13 +114,17 @@ func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFil
 		return false
 	}
 
-	keyFromArmored, err := crypto.NewKeyFromArmored(string(keyFileContent))
+	keys, err := parsePublicKeys(string(keyFileContent))
 	if err != nil {
-		logger.Errorf("Could not read PGP armored key: %v", err)
+		logger.Errorf("Could not parse PGP keys from %q: %v", keyFile.Name(), err)
 		return false
 	}
 
-	signingKey, err := crypto.PGP().Verify().VerificationKey(keyFromArmored).New()
+	verifyBuilder := crypto.PGP().Verify()
+	for _, key := range keys {
+		verifyBuilder = verifyBuilder.VerificationKey(key)
+	}
+	signingKey, err := verifyBuilder.New()
 	if err != nil {
 		logger.Errorf("Could not read PGP signing key: %v", err)
 		return false
@@ -105,7 +149,7 @@ func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFil
 	}
 
 	if err := verifyRes.SignatureError(); err != nil {
-		logger.Errorf("Could not verify PGP signature: %v", err)
+		logger.Errorf("Could not verify PGP signature (tried %d keys): %v", len(keys), err)
 		return false
 	}
 

--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -154,7 +154,7 @@ func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFil
 	}
 
 	if err := verifyRes.SignatureError(); err != nil {
-		logger.Errorf("Could not verify PGP signature (tried %d keys): %v", len(keys), err)
+		logger.Errorf("Could not verify PGP signature using %d loaded keys from %q: %v", len(keys), keyFile.Name(), err)
 		return false
 	}
 

--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
@@ -87,13 +88,13 @@ func parsePublicKeys(armored string) ([]*crypto.Key, error) {
 		block := pgpPublicKeyBegin + part
 		key, err := crypto.NewKeyFromArmored(block)
 		if err != nil {
-			logger.Debugf("Skipping unparseable PGP public key block: %v", err)
+			logger.Debugf("Skipping unparsable PGP public key block №%d: %v", i, err)
 			continue
 		}
 		keys = append(keys, key)
 	}
 	if len(keys) == 0 {
-		return nil, errors.New("no parseable PGP public keys found in key file")
+		return nil, errors.New("no parsable PGP public keys found in key file")
 	}
 	return keys, nil
 }
@@ -121,7 +122,7 @@ func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFil
 	}
 
 	verifyBuilder := crypto.PGP().Verify()
-	for _, key := range keys {
+	for key := range slices.Values(keys) {
 		verifyBuilder = verifyBuilder.VerificationKey(key)
 	}
 	signingKey, err := verifyBuilder.New()

--- a/lib/checksum_test.go
+++ b/lib/checksum_test.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -57,7 +58,7 @@ func sharedTestKeys(t *testing.T) (*crypto.Key, *crypto.Key, *crypto.Key) {
 	t.Helper()
 	sharedTestKeysOnce.Do(func() {
 		pgp := crypto.PGPWithProfile(profile.RFC4880())
-		for _, target := range []**crypto.Key{&sharedTestKeyA, &sharedTestKeyB, &sharedTestKeyC} {
+		for target := range slices.Values([]**crypto.Key{&sharedTestKeyA, &sharedTestKeyB, &sharedTestKeyC}) {
 			gen := pgp.KeyGeneration().AddUserId("tfswitch-test", "tfswitch-test@example.invalid").New()
 			k, err := gen.GenerateKeyWithSecurity(constants.StandardSecurity)
 			if err != nil {
@@ -97,7 +98,10 @@ func signDetached(t *testing.T, key *crypto.Key, payload []byte) []byte {
 
 // writeReadableTempFile writes content to a fresh file under t.TempDir()
 // and returns it opened read-only. checkSignatureOfChecksums closes every
-// file it receives, so each test hands out its own handle.
+// file it receives, so each test hands out its own handle. A t.Cleanup is
+// registered to close the handle even when a test aborts before
+// checkSignatureOfChecksums runs; os.File.Close on an already-closed file
+// is harmless (returns an error we ignore), so the belt-and-braces is safe.
 func writeReadableTempFile(t *testing.T, name string, content []byte) *os.File {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)
@@ -108,11 +112,12 @@ func writeReadableTempFile(t *testing.T, name string, content []byte) *os.File {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
+	t.Cleanup(func() { _ = f.Close() })
 	return f
 }
 
 func Test_parsePublicKeys_singleBlock(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, _, _ := sharedTestKeys(t)
 	keys, err := parsePublicKeys(armoredPublicKey(t, keyA))
 	if err != nil {
@@ -127,7 +132,7 @@ func Test_parsePublicKeys_singleBlock(t *testing.T) {
 }
 
 func Test_parsePublicKeys_multipleBlocks(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, keyB, _ := sharedTestKeys(t)
 	concatenated := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
 
@@ -147,8 +152,8 @@ func Test_parsePublicKeys_multipleBlocks(t *testing.T) {
 }
 
 func Test_parsePublicKeys_emptyInput(t *testing.T) {
-	InitLogger("TRACE")
-	for _, input := range []string{"", "   \n\n\t  "} {
+	InitLogger("DEBUG")
+	for input := range slices.Values([]string{"", "   \n\n\t  "}) {
 		_, err := parsePublicKeys(input)
 		if err == nil {
 			t.Errorf("parsePublicKeys(%q) expected error, got nil", input)
@@ -157,7 +162,7 @@ func Test_parsePublicKeys_emptyInput(t *testing.T) {
 }
 
 func Test_parsePublicKeys_mixedValidAndGarbage(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, _, _ := sharedTestKeys(t)
 	garbage := pgpPublicKeyBegin + "\nnot-a-real-armored-body\n-----END PGP PUBLIC KEY BLOCK-----\n"
 	concatenated := armoredPublicKey(t, keyA) + "\n" + garbage
@@ -175,7 +180,7 @@ func Test_parsePublicKeys_mixedValidAndGarbage(t *testing.T) {
 }
 
 func Test_checkSignatureOfChecksums_singleKey(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, _, _ := sharedTestKeys(t)
 	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
 	signature := signDetached(t, keyA, payload)
@@ -190,7 +195,7 @@ func Test_checkSignatureOfChecksums_singleKey(t *testing.T) {
 }
 
 func Test_checkSignatureOfChecksums_signerIsFirst(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, keyB, _ := sharedTestKeys(t)
 	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
 	signature := signDetached(t, keyA, payload)
@@ -210,7 +215,7 @@ func Test_checkSignatureOfChecksums_signerIsFirst(t *testing.T) {
 // key first and the active signing key second, and every release signed
 // with the successor key must still verify.
 func Test_checkSignatureOfChecksums_signerIsSecond(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, keyB, _ := sharedTestKeys(t)
 	payload := []byte("abc123  terraform_1.14.9_linux_amd64.zip\n")
 	signature := signDetached(t, keyB, payload)
@@ -221,12 +226,12 @@ func Test_checkSignatureOfChecksums_signerIsSecond(t *testing.T) {
 	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
 
 	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
-		t.Fatal("checkSignatureOfChecksums returned false with signer at position 1 (the #746 scenario)")
+		t.Fatal("checkSignatureOfChecksums returned false with signer at position 1 (GitHub issue #746 scenario)")
 	}
 }
 
 func Test_checkSignatureOfChecksums_noMatchingKey(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, keyB, keyC := sharedTestKeys(t)
 	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
 	signature := signDetached(t, keyC, payload)
@@ -242,7 +247,7 @@ func Test_checkSignatureOfChecksums_noMatchingKey(t *testing.T) {
 }
 
 func Test_checkSignatureOfChecksums_malformedKeyFile(t *testing.T) {
-	InitLogger("TRACE")
+	InitLogger("DEBUG")
 	keyA, _, _ := sharedTestKeys(t)
 	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
 	signature := signDetached(t, keyA, payload)

--- a/lib/checksum_test.go
+++ b/lib/checksum_test.go
@@ -48,9 +48,7 @@ func Test_checkChecksumMatches(t *testing.T) {
 // panicking instead of reporting the real cause.
 var (
 	sharedTestKeysOnce sync.Once
-	sharedTestKeyA     *crypto.Key
-	sharedTestKeyB     *crypto.Key
-	sharedTestKeyC     *crypto.Key
+	sharedTestKeyCache [3]*crypto.Key
 	sharedTestKeysErr  error
 )
 
@@ -58,20 +56,20 @@ func sharedTestKeys(t *testing.T) (*crypto.Key, *crypto.Key, *crypto.Key) {
 	t.Helper()
 	sharedTestKeysOnce.Do(func() {
 		pgp := crypto.PGPWithProfile(profile.RFC4880())
-		for target := range slices.Values([]**crypto.Key{&sharedTestKeyA, &sharedTestKeyB, &sharedTestKeyC}) {
+		for i := range sharedTestKeyCache {
 			gen := pgp.KeyGeneration().AddUserId("tfswitch-test", "tfswitch-test@example.invalid").New()
 			k, err := gen.GenerateKeyWithSecurity(constants.StandardSecurity)
 			if err != nil {
 				sharedTestKeysErr = err
 				return
 			}
-			*target = k
+			sharedTestKeyCache[i] = k
 		}
 	})
 	if sharedTestKeysErr != nil {
 		t.Fatalf("PGP key generation failed: %v", sharedTestKeysErr)
 	}
-	return sharedTestKeyA, sharedTestKeyB, sharedTestKeyC
+	return sharedTestKeyCache[0], sharedTestKeyCache[1], sharedTestKeyCache[2]
 }
 
 func armoredPublicKey(t *testing.T, key *crypto.Key) string {

--- a/lib/checksum_test.go
+++ b/lib/checksum_test.go
@@ -2,7 +2,14 @@ package lib
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/ProtonMail/gopenpgp/v3/constants"
+	"github.com/ProtonMail/gopenpgp/v3/crypto"
+	"github.com/ProtonMail/gopenpgp/v3/profile"
 )
 
 func Test_getChecksumFromHashFile(t *testing.T) {
@@ -26,5 +33,226 @@ func Test_checkChecksumMatches(t *testing.T) {
 
 	if got := checkChecksumMatches("../test-data/terraform_1.7.5_SHA256SUMS", targetFile); got != true {
 		t.Errorf("checkChecksumMatches() = %v, want %v", got, true)
+	}
+}
+
+// Key-generation cache. PGP keygen (RSA 2048, standard security) is the
+// slow part of these tests; generating one keyset per package-test run
+// keeps the full suite in the single-digit-seconds range.
+var (
+	sharedTestKeysOnce sync.Once
+	sharedTestKeyA     *crypto.Key
+	sharedTestKeyB     *crypto.Key
+	sharedTestKeyC     *crypto.Key
+)
+
+func sharedTestKeys(t *testing.T) (*crypto.Key, *crypto.Key, *crypto.Key) {
+	t.Helper()
+	sharedTestKeysOnce.Do(func() {
+		pgp := crypto.PGPWithProfile(profile.RFC4880())
+		for _, target := range []**crypto.Key{&sharedTestKeyA, &sharedTestKeyB, &sharedTestKeyC} {
+			gen := pgp.KeyGeneration().AddUserId("tfswitch-test", "tfswitch-test@example.invalid").New()
+			k, err := gen.GenerateKeyWithSecurity(constants.StandardSecurity)
+			if err != nil {
+				t.Fatalf("PGP key generation failed: %v", err)
+			}
+			*target = k
+		}
+	})
+	return sharedTestKeyA, sharedTestKeyB, sharedTestKeyC
+}
+
+func armoredPublicKey(t *testing.T, key *crypto.Key) string {
+	t.Helper()
+	armored, err := key.GetArmoredPublicKey()
+	if err != nil {
+		t.Fatalf("GetArmoredPublicKey: %v", err)
+	}
+	return armored
+}
+
+func signDetached(t *testing.T, key *crypto.Key, payload []byte) []byte {
+	t.Helper()
+	signer, err := crypto.PGP().Sign().SigningKey(key).Detached().New()
+	if err != nil {
+		t.Fatalf("build signing handle: %v", err)
+	}
+	sig, err := signer.Sign(payload, crypto.Auto)
+	if err != nil {
+		t.Fatalf("sign payload: %v", err)
+	}
+	return sig
+}
+
+// writeReadableTempFile writes content to a fresh file under t.TempDir()
+// and returns it opened read-only. checkSignatureOfChecksums closes every
+// file it receives, so each test hands out its own handle.
+func writeReadableTempFile(t *testing.T, name string, content []byte) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return f
+}
+
+func Test_parsePublicKeys_singleBlock(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, _, _ := sharedTestKeys(t)
+	keys, err := parsePublicKeys(armoredPublicKey(t, keyA))
+	if err != nil {
+		t.Fatalf("parsePublicKeys returned error: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(keys))
+	}
+	if keys[0].GetFingerprint() != keyA.GetFingerprint() {
+		t.Errorf("fingerprint mismatch: want %s, got %s", keyA.GetFingerprint(), keys[0].GetFingerprint())
+	}
+}
+
+func Test_parsePublicKeys_multipleBlocks(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, keyB, _ := sharedTestKeys(t)
+	concatenated := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
+
+	keys, err := parsePublicKeys(concatenated)
+	if err != nil {
+		t.Fatalf("parsePublicKeys returned error: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("want 2 keys, got %d", len(keys))
+	}
+	if keys[0].GetFingerprint() != keyA.GetFingerprint() {
+		t.Errorf("first key fingerprint mismatch: want %s, got %s", keyA.GetFingerprint(), keys[0].GetFingerprint())
+	}
+	if keys[1].GetFingerprint() != keyB.GetFingerprint() {
+		t.Errorf("second key fingerprint mismatch: want %s, got %s", keyB.GetFingerprint(), keys[1].GetFingerprint())
+	}
+}
+
+func Test_parsePublicKeys_emptyInput(t *testing.T) {
+	InitLogger("TRACE")
+	for _, input := range []string{"", "   \n\n\t  "} {
+		_, err := parsePublicKeys(input)
+		if err == nil {
+			t.Errorf("parsePublicKeys(%q) expected error, got nil", input)
+		}
+	}
+}
+
+func Test_parsePublicKeys_mixedValidAndGarbage(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, _, _ := sharedTestKeys(t)
+	garbage := pgpPublicKeyBegin + "\nnot-a-real-armored-body\n-----END PGP PUBLIC KEY BLOCK-----\n"
+	concatenated := armoredPublicKey(t, keyA) + "\n" + garbage
+
+	keys, err := parsePublicKeys(concatenated)
+	if err != nil {
+		t.Fatalf("parsePublicKeys returned error: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(keys))
+	}
+	if keys[0].GetFingerprint() != keyA.GetFingerprint() {
+		t.Errorf("fingerprint mismatch: want %s, got %s", keyA.GetFingerprint(), keys[0].GetFingerprint())
+	}
+}
+
+func Test_checkSignatureOfChecksums_singleKey(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, _, _ := sharedTestKeys(t)
+	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
+	signature := signDetached(t, keyA, payload)
+
+	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(armoredPublicKey(t, keyA)))
+	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
+	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
+
+	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+		t.Fatal("checkSignatureOfChecksums returned false for a single-key happy path")
+	}
+}
+
+func Test_checkSignatureOfChecksums_signerIsFirst(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, keyB, _ := sharedTestKeys(t)
+	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
+	signature := signDetached(t, keyA, payload)
+	keyring := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
+
+	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(keyring))
+	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
+	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
+
+	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+		t.Fatal("checkSignatureOfChecksums returned false with signer at position 0")
+	}
+}
+
+// Test_checkSignatureOfChecksums_signerIsSecond is the direct regression
+// test for issue #746: HashiCorp's current pgp-key.txt ships the expired
+// key first and the active signing key second, and every release signed
+// with the successor key must still verify.
+func Test_checkSignatureOfChecksums_signerIsSecond(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, keyB, _ := sharedTestKeys(t)
+	payload := []byte("abc123  terraform_1.14.9_linux_amd64.zip\n")
+	signature := signDetached(t, keyB, payload)
+	keyring := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
+
+	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(keyring))
+	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
+	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
+
+	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+		t.Fatal("checkSignatureOfChecksums returned false with signer at position 1 (the #746 scenario)")
+	}
+}
+
+func Test_checkSignatureOfChecksums_noMatchingKey(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, keyB, keyC := sharedTestKeys(t)
+	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
+	signature := signDetached(t, keyC, payload)
+	keyring := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
+
+	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(keyring))
+	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
+	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
+
+	if checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+		t.Fatal("checkSignatureOfChecksums returned true for signature made by a key not in the file")
+	}
+}
+
+func Test_checkSignatureOfChecksums_malformedKeyFile(t *testing.T) {
+	InitLogger("TRACE")
+	keyA, _, _ := sharedTestKeys(t)
+	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
+	signature := signDetached(t, keyA, payload)
+
+	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte("this is definitely not a PGP key"))
+	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
+	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
+
+	if checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+		t.Fatal("checkSignatureOfChecksums returned true for a malformed key file")
+	}
+	// Guard against strings.Split silently "parsing" a file that contains the
+	// BEGIN marker but nothing useful after it.
+	junkWithMarker := pgpPublicKeyBegin + "\nstill garbage\n-----END PGP PUBLIC KEY BLOCK-----\n"
+	if !strings.Contains(junkWithMarker, pgpPublicKeyBegin) {
+		t.Fatal("test fixture lost BEGIN marker; check constant")
+	}
+	keyFile2 := writeReadableTempFile(t, "pubkey2.asc", []byte(junkWithMarker))
+	hashFile2 := writeReadableTempFile(t, "SHA256SUMS", payload)
+	sigFile2 := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
+	if checkSignatureOfChecksums(keyFile2, hashFile2, sigFile2) {
+		t.Fatal("checkSignatureOfChecksums returned true for a file with only a malformed armored block")
 	}
 }

--- a/lib/checksum_test.go
+++ b/lib/checksum_test.go
@@ -39,11 +39,18 @@ func Test_checkChecksumMatches(t *testing.T) {
 // Key-generation cache. PGP keygen (RSA 2048, standard security) is the
 // slow part of these tests; generating one keyset per package-test run
 // keeps the full suite in the single-digit-seconds range.
+//
+// Failures inside the sync.Once closure are captured into sharedTestKeysErr
+// rather than calling t.Fatalf directly, because Once.Do marks itself done
+// regardless of how its closure exits: aborting the first caller with
+// t.Fatalf would leave every subsequent caller looking at nil keys and
+// panicking instead of reporting the real cause.
 var (
 	sharedTestKeysOnce sync.Once
 	sharedTestKeyA     *crypto.Key
 	sharedTestKeyB     *crypto.Key
 	sharedTestKeyC     *crypto.Key
+	sharedTestKeysErr  error
 )
 
 func sharedTestKeys(t *testing.T) (*crypto.Key, *crypto.Key, *crypto.Key) {
@@ -54,11 +61,15 @@ func sharedTestKeys(t *testing.T) (*crypto.Key, *crypto.Key, *crypto.Key) {
 			gen := pgp.KeyGeneration().AddUserId("tfswitch-test", "tfswitch-test@example.invalid").New()
 			k, err := gen.GenerateKeyWithSecurity(constants.StandardSecurity)
 			if err != nil {
-				t.Fatalf("PGP key generation failed: %v", err)
+				sharedTestKeysErr = err
+				return
 			}
 			*target = k
 		}
 	})
+	if sharedTestKeysErr != nil {
+		t.Fatalf("PGP key generation failed: %v", sharedTestKeysErr)
+	}
 	return sharedTestKeyA, sharedTestKeyB, sharedTestKeyC
 }
 

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -97,11 +97,12 @@ type DownloadProductTestConfig struct {
 	ZipFileChecksum     string
 	ChecksumFileContent string
 	PublicKey           string
-	// SecondaryPublicKey, when non-empty, is prepended to PublicKey in
-	// the armored response so that the signing key sits second in the
-	// concatenated file. This mirrors HashiCorp's pgp-key.txt layout
-	// during key rotations and is the shape that regressed in GitHub issue #746.
-	SecondaryPublicKey string
+	// LeadingPublicKey, when non-empty, is prepended to PublicKey in
+	// the armored response so that it becomes the first block and the
+	// signing key sits second in the concatenated file. This mirrors
+	// HashiCorp's pgp-key.txt layout during key rotations and is the
+	// shape that regressed in GitHub issue #746.
+	LeadingPublicKey string
 }
 
 //nolint:gocyclo
@@ -180,8 +181,8 @@ func setupTestDownloadServer(t *testing.T, downloadProductTestConfig *DownloadPr
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusOK)
 			body := downloadProductTestConfig.PublicKey
-			if downloadProductTestConfig.SecondaryPublicKey != "" {
-				body = downloadProductTestConfig.SecondaryPublicKey + "\n\n" + body
+			if downloadProductTestConfig.LeadingPublicKey != "" {
+				body = downloadProductTestConfig.LeadingPublicKey + "\n\n" + body
 			}
 			if _, err := w.Write([]byte(body)); err != nil {
 				t.Error(err)
@@ -417,7 +418,7 @@ func TestDownloadProductFromURL_multiple_public_keys(t *testing.T) {
 	}
 
 	downloadProductTestConfig := DownloadProductTestConfig{
-		SecondaryPublicKey: companionArmored,
+		LeadingPublicKey: companionArmored,
 	}
 	mockServer := setupTestDownloadServer(t, &downloadProductTestConfig)
 	defer mockServer.Close()

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -408,7 +408,7 @@ func TestDownloadProductFromURL_multiple_public_keys(t *testing.T) {
 	// has to skip past it and try the second one.
 	pgp4880 := crypto.PGPWithProfile(profile.RFC4880())
 	companionGen := pgp4880.KeyGeneration().AddUserId("TestProductCompanion", "companion@localhost.com").New()
-	companionKey, err := companionGen.GenerateKeyWithSecurity(constants.HighSecurity)
+	companionKey, err := companionGen.GenerateKeyWithSecurity(constants.StandardSecurity)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -97,6 +97,11 @@ type DownloadProductTestConfig struct {
 	ZipFileChecksum     string
 	ChecksumFileContent string
 	PublicKey           string
+	// SecondaryPublicKey, when non-empty, is prepended to PublicKey in
+	// the armored response so that the signing key sits second in the
+	// concatenated file. This mirrors HashiCorp's pgp-key.txt layout
+	// during key rotations and is the shape that regressed in #746.
+	SecondaryPublicKey string
 }
 
 //nolint:gocyclo
@@ -174,7 +179,11 @@ func setupTestDownloadServer(t *testing.T, downloadProductTestConfig *DownloadPr
 		case "/testproduct/gpg-key.txt":
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusOK)
-			if _, err := w.Write([]byte(downloadProductTestConfig.PublicKey)); err != nil {
+			body := downloadProductTestConfig.PublicKey
+			if downloadProductTestConfig.SecondaryPublicKey != "" {
+				body = downloadProductTestConfig.SecondaryPublicKey + "\n\n" + body
+			}
+			if _, err := w.Write([]byte(body)); err != nil {
 				t.Error(err)
 			}
 		case "/productdownload/2.1.0/my_product_download_2.1.0_linux_amd64.zip":
@@ -382,5 +391,61 @@ func TestDownloadProductFromURL_invalid_public_key(t *testing.T) {
 		t.Fatal("DownloadProductFromURL did not throw error")
 	} else if expectedError := "Signature of checksum file could not be verified"; !strings.Contains(err.Error(), expectedError) {
 		t.Fatalf("DownloadProductFromURL did not throw expected error. Expected: %q, Actual: %q", expectedError, err)
+	}
+}
+
+// TestDownloadProductFromURL_multiple_public_keys exercises the full
+// install path when the served public-key file contains more than one
+// armored block and the signing key sits second, mirroring HashiCorp's
+// pgp-key.txt layout during rotations (issue #746).
+func TestDownloadProductFromURL_multiple_public_keys(t *testing.T) {
+	logger = InitLogger("DEBUG")
+
+	// Generate a throwaway companion key. It never signs anything and is
+	// unrelated to the signing key that setupTestDownloadServer builds;
+	// its job is to be the first armored block so the code under test
+	// has to skip past it and try the second one.
+	pgp4880 := crypto.PGPWithProfile(profile.RFC4880())
+	companionGen := pgp4880.KeyGeneration().AddUserId("TestProductCompanion", "companion@localhost.com").New()
+	companionKey, err := companionGen.GenerateKeyWithSecurity(constants.HighSecurity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	companionArmored, err := companionKey.GetArmoredPublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	downloadProductTestConfig := DownloadProductTestConfig{
+		SecondaryPublicKey: companionArmored,
+	}
+	mockServer := setupTestDownloadServer(t, &downloadProductTestConfig)
+	defer mockServer.Close()
+
+	mockProduct := TerraformProduct{
+		ProductDetails{
+			ID:             "myproduct",
+			Name:           "Mock Product",
+			DefaultMirror:  mockServer.URL + "/productdownload",
+			VersionPrefix:  "myprod_",
+			ExecutableName: "myprod",
+			ArchivePrefix:  "my_product_download_",
+			PublicKeyId:    downloadProductTestConfig.GpgFingerprint,
+			PublicKeyURLs:  []string{mockServer.URL + "/testproduct/gpg-key.txt"},
+		},
+	}
+
+	tempDir, err := os.MkdirTemp("", "addRecentVersion")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	zipFilePath, err := DownloadProductFromURL(mockProduct, tempDir, mockProduct.GetArtifactUrl(mockServer.URL+"/productdownload", "2.1.0"), "2.1.0", mockProduct.GetArchivePrefix(), "linux", "amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expectedZipPath := filepath.Join(tempDir, "my_product_download_2.1.0_linux_amd64.zip"); zipFilePath != expectedZipPath {
+		t.Errorf("Returned zipFile not expected path. Expected: %q, actual: %q", expectedZipPath, zipFilePath)
 	}
 }

--- a/lib/download_test.go
+++ b/lib/download_test.go
@@ -100,7 +100,7 @@ type DownloadProductTestConfig struct {
 	// SecondaryPublicKey, when non-empty, is prepended to PublicKey in
 	// the armored response so that the signing key sits second in the
 	// concatenated file. This mirrors HashiCorp's pgp-key.txt layout
-	// during key rotations and is the shape that regressed in #746.
+	// during key rotations and is the shape that regressed in GitHub issue #746.
 	SecondaryPublicKey string
 }
 

--- a/lib/install.go
+++ b/lib/install.go
@@ -361,7 +361,7 @@ func InstallProductOption(product Product, listAll, dryRun, showRequiredFlag boo
 		}
 
 		/* prompt user to select version of product */
-		if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115: file descriptors from os.Stdin/Stdout are always valid small integers
 			//nolint:revive // error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
 			return errors.New("Interactive prompt is not meant for non-interactive terminal (please use command line flags in such case)")
 		}

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -57,7 +57,7 @@ func isColorLogging() bool {
 		return false
 	} else if color.SupportColor() {
 		if os.Getenv("FORCE_COLOR") == "" {
-			return term.IsTerminal(int(os.Stdout.Fd()))
+			return term.IsTerminal(int(os.Stdout.Fd())) //nolint:gosec // G115: file descriptor from os.Stdout is always a valid small integer
 		}
 		return true
 	}


### PR DESCRIPTION
## Summary

Fixes #746. HashiCorp's `pgp-key.txt` at `https://www.hashicorp.com/.well-known/pgp-key.txt` currently ships **two** armored PGP public key blocks: the original block (whose self-signature expired on 2026-04-18) followed by a refreshed block with an extended self-signature. Releases such as Terraform 1.14.9 are signed using the refreshed block.

`lib/checksum.go` parses the downloaded key file with `crypto.NewKeyFromArmored`, and gopenpgp v3 is explicit that this function reads exactly one entity and errors on multi-entity input. Only the first block is ever considered, so every install that needs the refreshed key fails fatally with:

```
ERROR Could not verify PGP signature: Signature Verification Error: Invalid signature caused by openpgp: key expired
FATAL Error downloading: Signature of checksum file could not be verified
```

HashiCorp confirmed the root cause in hashicorp/terraform#38404 and the same pattern is breaking hc-install, atlantis, and older versions of tenv. See also hashicorp/terraform#38418.

## The fix

Parse every armored block from the key file and register each parsed key with gopenpgp's verify handle builder. Successive `VerificationKey(k)` calls append to the builder's internal keyring, and `VerifyDetached` picks the key matching the signature's KeyID automatically.

```go
keys, err := parsePublicKeys(string(keyFileContent))
// ...
verifyBuilder := crypto.PGP().Verify()
for _, key := range keys {
    verifyBuilder = verifyBuilder.VerificationKey(key)
}
signingKey, err := verifyBuilder.New()
```

`strings.Split` on the BEGIN marker is the pragmatic parse strategy: `armor.Decode(io.Reader)` from `ProtonMail/go-crypto` documents that the reader is unusable after one call so it cannot be looped, and gopenpgp v3 does not expose a plural `NewKeysFromArmored`. Blocks that fail to parse are logged at Debug and skipped; an error is returned only when zero usable keys remain.

## Test matrix

`lib/checksum_test.go` (new unit tests, ephemeral keys generated via the pattern already used in `lib/download_test.go`):

- `Test_parsePublicKeys_singleBlock` - one armored block returns one key.
- `Test_parsePublicKeys_multipleBlocks` - two armored blocks return both keys in file order.
- `Test_parsePublicKeys_emptyInput` - empty / whitespace-only input returns an error.
- `Test_parsePublicKeys_mixedValidAndGarbage` - valid block plus a malformed block returns only the valid key; malformed block is Debug-logged and skipped.
- `Test_checkSignatureOfChecksums_singleKey` - happy-path regression for the single-block case (backward compatibility).
- `Test_checkSignatureOfChecksums_signerIsFirst` - two keys, the one at position 0 signed the checksum: verifies.
- `Test_checkSignatureOfChecksums_signerIsSecond` - two keys, the one at position 1 signed the checksum. **Direct regression test for this issue.**
- `Test_checkSignatureOfChecksums_noMatchingKey` - signature made by a key absent from the file: rejected, error mentions `tried 2 keys`.
- `Test_checkSignatureOfChecksums_malformedKeyFile` - key file contains garbage or only a marker with no body: rejected without panic.

`lib/download_test.go`:

- `DownloadProductTestConfig` gains a `SecondaryPublicKey` field; when set, `setupTestDownloadServer` serves the secondary key concatenated in front of `PublicKey` (two newlines between them) so the signing key ends up second - the shape of HashiCorp's current file.
- `TestDownloadProductFromURL_multiple_public_keys` exercises the full download + verification path against a two-block key file.

## Verification

Locally reproducing the `build.yml` pipeline (`go vet`, `go fmt`, `go build`, `go test -v ./...`, plus the `test-data/integration-tests/*` loop) comes back clean. `golangci-lint` with `.github/linters/.golangci.yml` reports no new issues. `govulncheck` reports no vulnerabilities.

End-to-end smoke test against the real HashiCorp endpoint (with a fresh key cache):

```
$ rm -f ~/.local/share/.terraform.versions/terraform_72D7468F.asc
$ ./build/tfswitch 1.14.9
INFO  Verifying PGP signature of checksum file: ".../terraform_1.14.9_SHA256SUMS"
INFO  Checksum file PGP signature verification successful
INFO  Switched Terraform to version "1.14.9"
```

## Scope

The issue also suggested adding a `--skip-pgp-verify` escape hatch. I've kept that out of this PR because the multi-key fix removes the motivating failure and a new flag would expand the security surface. Similarly, adding TTL-based refresh to the cached key file (so stale caches self-heal on future rotations) felt like a separate concern worth its own PR. Happy to follow up on either if a maintainer would like them.

No user-facing behavior changes beyond "installs that used to fail now succeed", so no README or `www/docs/usage/` updates. `CHANGELOG.md` is generated from PR labels per `CHANGELOG.howto.md`; the auto-applied `enhancement` label (and/or a manually added `bug`) routes this entry into the next release's **Fixed** section.

## Test plan

- [x] `go vet ./...`
- [x] `go fmt ./...` (no changes)
- [x] `go build -v ./...`
- [x] `go test -v ./...` (full suite passes, including 9 new tests)
- [x] Integration test loop in `test-data/integration-tests/*` (all 7 pass)
- [x] `golangci-lint` with the repo config (no new issues)
- [x] `govulncheck` (clean)
- [x] Manual install of Terraform 1.14.9 succeeds with a fresh key cache
- [x] Manual install of Terraform 1.14.8 still succeeds (backward compatibility)