### PR TITLE
fix(pgp): Fallback to legacy builtin PGP key

### DIFF
--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -78,12 +78,10 @@ func parsePublicKeys(armored string) ([]*crypto.Key, error) {
 	// body of one block. Re-prepending the marker rather than trimming
 	// preserves the mandatory blank line between the marker/headers and
 	// the base64 payload that RFC 4880 armor requires.
+	// Along with that, skip the part[0] altogether.
 	parts := strings.Split(armored, pgpPublicKeyBegin)
 	keys := make([]*crypto.Key, 0, len(parts)-1)
-	for i, part := range parts {
-		if i == 0 {
-			continue
-		}
+	for i, part := range parts[1:] {
 		block := pgpPublicKeyBegin + part
 		key, err := crypto.NewKeyFromArmored(block)
 		if err != nil {

--- a/lib/checksum.go
+++ b/lib/checksum.go
@@ -44,9 +44,6 @@ func getChecksumFromHashFile(signatureFilePath string, terraformFileName string)
 // checkChecksumMatches This will calculate and compare the check sum of the downloaded zip file
 func checkChecksumMatches(hashFile string, targetFile *os.File) bool {
 	logger.Debugf("Checksum comparison for %q", targetFile.Name())
-	var fileHandlersToClose []*os.File
-	fileHandlersToClose = append(fileHandlersToClose, targetFile)
-	defer closeFileHandlers(fileHandlersToClose)
 
 	_, fileName := filepath.Split(targetFile.Name())
 	expectedChecksum, err := getChecksumFromHashFile(hashFile, fileName)
@@ -102,36 +99,10 @@ func parsePublicKeys(armored string) ([]*crypto.Key, error) {
 }
 
 // checkSignatureOfChecksums This will verify the signature of the file containing the hash sums
-func checkSignatureOfChecksums(keyFile *os.File, hashFile *os.File, signatureFile *os.File) bool {
-	var fileHandlersToClose []*os.File
-	fileHandlersToClose = append(fileHandlersToClose, keyFile)
-	fileHandlersToClose = append(fileHandlersToClose, hashFile)
-	fileHandlersToClose = append(fileHandlersToClose, signatureFile)
-	defer closeFileHandlers(fileHandlersToClose)
-
-	logger.Infof("Verifying PGP signature of checksum file: %q", hashFile.Name())
-
-	keyFileContent, err := io.ReadAll(keyFile)
-	if err != nil {
-		logger.Errorf("Could not read PGP key file %q: %v", keyFile.Name(), err)
-		return false
-	}
-
-	hashFileContent, err := io.ReadAll(hashFile)
-	if err != nil {
-		logger.Errorf("Could not read hash file %q: %v", hashFile.Name(), err)
-		return false
-	}
-
-	signatureContent, err := io.ReadAll(signatureFile)
-	if err != nil {
-		logger.Errorf("Could not read PGP signature file %q: %v", signatureFile.Name(), err)
-		return false
-	}
-
+func checkSignatureOfChecksums(keyFileContent []byte, hashFileContent []byte, signatureContent []byte) bool {
 	keys, err := parsePublicKeys(string(keyFileContent))
 	if err != nil {
-		logger.Errorf("Could not parse PGP keys from %q: %v", keyFile.Name(), err)
+		logger.Errorf("Could not parse PGP keys: %v", err)
 		return false
 	}
 

--- a/lib/checksum_test.go
+++ b/lib/checksum_test.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -94,26 +93,6 @@ func signDetached(t *testing.T, key *crypto.Key, payload []byte) []byte {
 	return sig
 }
 
-// writeReadableTempFile writes content to a fresh file under t.TempDir()
-// and returns it opened read-only. checkSignatureOfChecksums closes every
-// file it receives, so each test hands out its own handle. A t.Cleanup is
-// registered to close the handle even when a test aborts before
-// checkSignatureOfChecksums runs; os.File.Close on an already-closed file
-// is harmless (returns an error we ignore), so the belt-and-braces is safe.
-func writeReadableTempFile(t *testing.T, name string, content []byte) *os.File {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, content, 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	t.Cleanup(func() { _ = f.Close() })
-	return f
-}
-
 func Test_parsePublicKeys_singleBlock(t *testing.T) {
 	InitLogger("DEBUG")
 	keyA, _, _ := sharedTestKeys(t)
@@ -183,11 +162,7 @@ func Test_checkSignatureOfChecksums_singleKey(t *testing.T) {
 	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
 	signature := signDetached(t, keyA, payload)
 
-	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(armoredPublicKey(t, keyA)))
-	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
-	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
-
-	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+	if !checkSignatureOfChecksums([]byte(armoredPublicKey(t, keyA)), payload, signature) {
 		t.Fatal("checkSignatureOfChecksums returned false for a single-key happy path")
 	}
 }
@@ -199,11 +174,7 @@ func Test_checkSignatureOfChecksums_signerIsFirst(t *testing.T) {
 	signature := signDetached(t, keyA, payload)
 	keyring := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
 
-	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(keyring))
-	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
-	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
-
-	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+	if !checkSignatureOfChecksums([]byte(keyring), payload, signature) {
 		t.Fatal("checkSignatureOfChecksums returned false with signer at position 0")
 	}
 }
@@ -219,11 +190,7 @@ func Test_checkSignatureOfChecksums_signerIsSecond(t *testing.T) {
 	signature := signDetached(t, keyB, payload)
 	keyring := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
 
-	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(keyring))
-	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
-	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
-
-	if !checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+	if !checkSignatureOfChecksums([]byte(keyring), payload, signature) {
 		t.Fatal("checkSignatureOfChecksums returned false with signer at position 1 (GitHub issue #746 scenario)")
 	}
 }
@@ -235,11 +202,7 @@ func Test_checkSignatureOfChecksums_noMatchingKey(t *testing.T) {
 	signature := signDetached(t, keyC, payload)
 	keyring := armoredPublicKey(t, keyA) + "\n" + armoredPublicKey(t, keyB)
 
-	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte(keyring))
-	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
-	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
-
-	if checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+	if checkSignatureOfChecksums([]byte(keyring), payload, signature) {
 		t.Fatal("checkSignatureOfChecksums returned true for signature made by a key not in the file")
 	}
 }
@@ -250,11 +213,7 @@ func Test_checkSignatureOfChecksums_malformedKeyFile(t *testing.T) {
 	payload := []byte("abc123  terraform_1.7.5_linux_amd64.zip\n")
 	signature := signDetached(t, keyA, payload)
 
-	keyFile := writeReadableTempFile(t, "pubkey.asc", []byte("this is definitely not a PGP key"))
-	hashFile := writeReadableTempFile(t, "SHA256SUMS", payload)
-	sigFile := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
-
-	if checkSignatureOfChecksums(keyFile, hashFile, sigFile) {
+	if checkSignatureOfChecksums([]byte("this is definitely not a PGP key"), payload, signature) {
 		t.Fatal("checkSignatureOfChecksums returned true for a malformed key file")
 	}
 	// Guard against strings.Split silently "parsing" a file that contains the
@@ -263,10 +222,7 @@ func Test_checkSignatureOfChecksums_malformedKeyFile(t *testing.T) {
 	if !strings.Contains(junkWithMarker, pgpPublicKeyBegin) {
 		t.Fatal("test fixture lost BEGIN marker; check constant")
 	}
-	keyFile2 := writeReadableTempFile(t, "pubkey2.asc", []byte(junkWithMarker))
-	hashFile2 := writeReadableTempFile(t, "SHA256SUMS", payload)
-	sigFile2 := writeReadableTempFile(t, "SHA256SUMS.sig", signature)
-	if checkSignatureOfChecksums(keyFile2, hashFile2, sigFile2) {
+	if checkSignatureOfChecksums([]byte(junkWithMarker), payload, signature) {
 		t.Fatal("checkSignatureOfChecksums returned true for a file with only a malformed armored block")
 	}
 }

--- a/lib/download.go
+++ b/lib/download.go
@@ -61,12 +61,14 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		logger.Errorf("Could not open public key %q: %v", pubKeyFilename, err)
 		return "", err
 	}
+	defer publicKeyFile.Close()
 
 	signatureFile, err := os.Open(hashSigFilePath)
 	if err != nil {
 		logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, err)
 		return "", err
 	}
+	defer signatureFile.Close()
 
 	targetFile, err := os.Open(zipFilePath)
 	if err != nil {
@@ -79,17 +81,12 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		logger.Errorf("Could not open hash file %q: %v", hashFilePath, err)
 		return "", err
 	}
+	defer hashFile.Close()
 
 	var filesToCleanup []string
 	filesToCleanup = append(filesToCleanup, hashFilePath)
 	filesToCleanup = append(filesToCleanup, hashSigFilePath)
 	defer cleanup(filesToCleanup, &wg)
-
-	var fileHandlersToClose []*os.File
-	fileHandlersToClose = append(fileHandlersToClose, publicKeyFile)
-	fileHandlersToClose = append(fileHandlersToClose, hashFile)
-	fileHandlersToClose = append(fileHandlersToClose, signatureFile)
-	defer closeFileHandlers(fileHandlersToClose)
 
 	// CAUTION: Skip PGP signature verification of checksum file if TF_SKIP_SIGNATURE_VERIFICATION
 	// environment variable is set to true-ish value: 1, t, T, TRUE, true, True

--- a/lib/download.go
+++ b/lib/download.go
@@ -18,6 +18,7 @@ func DownloadFromURL(installLocation, mirrorURL, tfversion, versionPrefix, goos,
 	return DownloadProductFromURL(product, installLocation, mirrorURL, tfversion, versionPrefix, goos, goarch)
 }
 
+//nolint:gocyclo
 func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversion, versionPrefix, goos, goarch string) (string, error) {
 	var wg sync.WaitGroup
 	defer wg.Done()
@@ -126,22 +127,22 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 					"Falling back to %s", pubKeyFilename, legacyBuiltinKeyIdentifier,
 			)
 
-			tmpFile, err := os.CreateTemp("", "tfswitch.pubkey.asc.*")
+			tmpFile, tmpFileErr := os.CreateTemp("", "tfswitch.pubkey.asc.*")
 			if err != nil {
 				logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, err)
 				targetFile.Close()
 				os.Remove(targetFile.Name())
-				return "", err
+				return "", tmpFileErr
 			}
 
 			defer tmpFile.Close()
 			defer os.Remove(tmpFile.Name())
 
-			if _, err := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); err != nil {
+			if _, writeStringErr := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); writeStringErr != nil {
 				logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, err)
 				targetFile.Close()
 				os.Remove(targetFile.Name())
-				return "", err
+				return "", writeStringErr
 			}
 
 			tmpFile, err = os.Open(tmpFile.Name())

--- a/lib/download.go
+++ b/lib/download.go
@@ -109,54 +109,57 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	} else {
 		verified := checkSignatureOfChecksums(publicKeyFile, hashFile, signatureFile)
 		if !verified {
-			if product.GetPublicKeyLegacyLiteral() != "" {
-				legacyBuiltinKeyIdentifier := "legacy builtin PGP public key"
-				logger.Warnf(
-					"Checksum file PGP signature verification failed with public key from %q file. "+
-						"Falling back to %s", pubKeyFilename, legacyBuiltinKeyIdentifier,
-				)
+			// Fail fast if there is no legacy builtin PGP public key to fall back to
+			if product.GetPublicKeyLegacyLiteral() == "" {
+				return "", errors.New("Signature of checksum file could not be verified")
+			}
 
-				tmpFile, err := os.CreateTemp("", "tfswitch.pubkey.asc.*")
-				if err != nil {
-					logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, err)
-					os.Remove(targetFile.Name())
-					return "", err
-				}
+			legacyBuiltinKeyIdentifier := "legacy builtin PGP public key"
+			logger.Warnf(
+				"Checksum file PGP signature verification failed with public key from %q file. "+
+					"Falling back to %s", pubKeyFilename, legacyBuiltinKeyIdentifier,
+			)
 
-				defer tmpFile.Close()
-				defer os.Remove(tmpFile.Name())
+			tmpFile, err := os.CreateTemp("", "tfswitch.pubkey.asc.*")
+			if err != nil {
+				logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, err)
+				os.Remove(targetFile.Name())
+				return "", err
+			}
 
-				if _, err := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); err != nil {
-					logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, err)
-					os.Remove(targetFile.Name())
-					return "", err
-				}
+			defer tmpFile.Close()
+			defer os.Remove(tmpFile.Name())
 
-				tmpFile, err = os.Open(tmpFile.Name())
-				if err != nil {
-					logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile, err)
-					os.Remove(targetFile.Name())
-					return "", err
-				}
+			if _, err := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); err != nil {
+				logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, err)
+				os.Remove(targetFile.Name())
+				return "", err
+			}
 
-				signatureFile, err := os.Open(hashSigFilePath)
-				if err != nil {
-					logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, err)
-					return "", err
-				}
+			tmpFile, err = os.Open(tmpFile.Name())
+			if err != nil {
+				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile, err)
+				os.Remove(targetFile.Name())
+				return "", err
+			}
 
-				hashFile, err := os.Open(hashFilePath)
-				if err != nil {
-					logger.Errorf("Could not open hash file %q: %v", hashFilePath, err)
-					return "", err
-				}
+			signatureFile, err := os.Open(hashSigFilePath)
+			if err != nil {
+				logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, err)
+				return "", err
+			}
 
-				verified := checkSignatureOfChecksums(tmpFile, hashFile, signatureFile)
-				if !verified {
-					logger.Error("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
-					os.Remove(targetFile.Name())
-					return "", errors.New("Signature of checksum file could not be verified")
-				}
+			hashFile, err := os.Open(hashFilePath)
+			if err != nil {
+				logger.Errorf("Could not open hash file %q: %v", hashFilePath, err)
+				return "", err
+			}
+
+			verified := checkSignatureOfChecksums(tmpFile, hashFile, signatureFile)
+			if !verified {
+				logger.Error("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
+				os.Remove(targetFile.Name())
+				return "", errors.New("Signature of checksum file could not be verified")
 			}
 		}
 	}

--- a/lib/download.go
+++ b/lib/download.go
@@ -153,19 +153,20 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 				return "", tmpFileErr
 			}
 
-			signatureFile, signatureFileErr := os.Open(hashSigFilePath)
-			if signatureFileErr != nil {
-				logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, signatureFileErr)
-				return "", signatureFileErr
+			fallbackSignatureFile, fallbackSignatureFileErr := os.Open(hashSigFilePath)
+			if fallbackSignatureFileErr != nil {
+				logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, fallbackSignatureFileErr)
+				return "", fallbackSignatureFileErr
 			}
 
-			hashFile, hashFileErr := os.Open(hashFilePath)
-			if hashFileErr != nil {
-				logger.Errorf("Could not open hash file %q: %v", hashFilePath, hashFileErr)
-				return "", hashFileErr
+			fallbackHashFile, fallbackHashFileErr := os.Open(hashFilePath)
+			if fallbackHashFileErr != nil {
+				logger.Errorf("Could not open hash file %q: %v", hashFilePath, fallbackHashFileErr)
+				fallbackSignatureFile.Close()
+				return "", fallbackHashFileErr
 			}
 
-			verified := checkSignatureOfChecksums(tmpFile, hashFile, signatureFile)
+			verified := checkSignatureOfChecksums(tmpFile, fallbackHashFile, fallbackSignatureFile)
 			if !verified {
 				logger.Errorf("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
 				targetFile.Close()

--- a/lib/download.go
+++ b/lib/download.go
@@ -84,6 +84,12 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	filesToCleanup = append(filesToCleanup, hashSigFilePath)
 	defer cleanup(filesToCleanup, &wg)
 
+	var fileHandlersToClose []*os.File
+	fileHandlersToClose = append(fileHandlersToClose, publicKeyFile)
+	fileHandlersToClose = append(fileHandlersToClose, hashFile)
+	fileHandlersToClose = append(fileHandlersToClose, signatureFile)
+	defer closeFileHandlers(fileHandlersToClose)
+
 	// CAUTION: Skip PGP signature verification of checksum file if TF_SKIP_SIGNATURE_VERIFICATION
 	// environment variable is set to true-ish value: 1, t, T, TRUE, true, True
 	// THIS IS NOT RECOMMENDED AND SHOULD ONLY BE USED FOR TESTING PURPOSES!

--- a/lib/download.go
+++ b/lib/download.go
@@ -3,6 +3,7 @@ package lib
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -29,6 +30,8 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	// nolint:revive // FIXME: var-naming: var hashSignatureUrl should be hashSignatureURL (revive)
 	hashSignatureUrl := mirrorURL + "/" + versionPrefix + tfversion + "_SHA256SUMS." + product.GetShaSignatureSuffix()
 
+	match := false
+
 	pubKeyFilename, err := downloadPublicKey(product, installLocation, &wg)
 	if err != nil {
 		logger.Error("Could not download public PGP key file")
@@ -41,6 +44,11 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		logger.Error("Could not download zip file")
 		return "", err
 	}
+	defer func() {
+		if !match {
+			os.Remove(zipFilePath)
+		}
+	}()
 
 	logger.Infof("Downloading %q", hashUrl)
 	hashFilePath, err := downloadFromURL(installLocation, hashUrl, &wg)
@@ -48,6 +56,7 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		logger.Error("Could not download hash file")
 		return "", err
 	}
+	defer os.Remove(hashFilePath)
 
 	logger.Infof("Downloading %q", hashSignatureUrl)
 	hashSigFilePath, err := downloadFromURL(installLocation, hashSignatureUrl, &wg)
@@ -55,6 +64,7 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		logger.Error("Could not download hash signature file")
 		return "", err
 	}
+	defer os.Remove(hashSigFilePath)
 
 	publicKeyFile, err := os.Open(pubKeyFilename)
 	if err != nil {
@@ -75,6 +85,7 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		logger.Errorf("Could not open zip file %q: %v", zipFilePath, err)
 		return "", err
 	}
+	defer targetFile.Close()
 
 	hashFile, err := os.Open(hashFilePath)
 	if err != nil {
@@ -83,11 +94,24 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	}
 	defer hashFile.Close()
 
-	var filesToCleanup []string
-	filesToCleanup = append(filesToCleanup, hashFilePath)
-	filesToCleanup = append(filesToCleanup, hashSigFilePath)
-	defer cleanup(filesToCleanup, &wg)
+	var verifySucceed bool
+	if verifySucceed, err = verifySignature(product, publicKeyFile, hashFile, signatureFile); err != nil {
+		return "", err
+	} else if !verifySucceed {
+		return "", fmt.Errorf("Unable to verify checksum signature against PGP key")
+	}
 
+	match = checkChecksumMatches(hashFilePath, targetFile)
+	if !match {
+		return "", errors.New("Checksums did not match")
+	}
+
+	return zipFilePath, err
+}
+
+// verifySignature: Verify signature of hash file.
+// If
+func verifySignature(product Product, publicKeyFile, hashFile, signatureFile *os.File) (bool, error) {
 	// CAUTION: Skip PGP signature verification of checksum file if TF_SKIP_SIGNATURE_VERIFICATION
 	// environment variable is set to true-ish value: 1, t, T, TRUE, true, True
 	// THIS IS NOT RECOMMENDED AND SHOULD ONLY BE USED FOR TESTING PURPOSES!
@@ -97,11 +121,11 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	}
 	skipSignatureVerification, err := strconv.ParseBool(skipSignatureVerificationStr)
 	if err != nil {
-		logger.Debugf(
+		logger.Warnf(
 			"Unable to parse \"TF_SKIP_SIGNATURE_VERIFICATION\" env var value %q, defaulting to \"false\"",
 			skipSignatureVerificationStr,
 		)
-		skipSignatureVerification = false
+		return true, nil
 	}
 
 	if skipSignatureVerification {
@@ -110,75 +134,48 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 				"\"TF_SKIP_SIGNATURE_VERIFICATION\" environment variable being set",
 		)
 		logger.Warn("!!! THIS IS NOT RECOMMENDED AND SHOULD ONLY BE USED FOR TESTING PURPOSES !!!")
-	} else {
-		verified := checkSignatureOfChecksums(publicKeyFile, hashFile, signatureFile)
-		if !verified {
-			// Fail fast if there is no legacy builtin PGP public key to fall back to
-			if product.GetPublicKeyLegacyLiteral() == "" {
-				return "", errors.New("Signature of checksum file could not be verified")
-			}
-
-			legacyBuiltinKeyIdentifier := "legacy builtin PGP public key"
-			logger.Warnf(
-				"Checksum file PGP signature verification failed with public key from %q file. "+
-					"Falling back to %s", pubKeyFilename, legacyBuiltinKeyIdentifier,
-			)
-
-			tmpFile, tmpFileErr := os.CreateTemp("", "tfswitch.pubkey.asc.*")
-			if tmpFileErr != nil {
-				logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, tmpFileErr)
-				targetFile.Close()
-				os.Remove(targetFile.Name())
-				return "", tmpFileErr
-			}
-
-			defer tmpFile.Close()
-			defer os.Remove(tmpFile.Name())
-
-			if _, writeStringErr := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); writeStringErr != nil {
-				logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, writeStringErr)
-				targetFile.Close()
-				os.Remove(targetFile.Name())
-				return "", writeStringErr
-			}
-
-			tmpFileRead, tmpFileReadErr := os.Open(tmpFile.Name())
-			if tmpFileReadErr != nil {
-				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile.Name(), tmpFileReadErr)
-				targetFile.Close()
-				os.Remove(targetFile.Name())
-				return "", tmpFileReadErr
-			}
-
-			fallbackSignatureFile, fallbackSignatureFileErr := os.Open(hashSigFilePath)
-			if fallbackSignatureFileErr != nil {
-				logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, fallbackSignatureFileErr)
-				return "", fallbackSignatureFileErr
-			}
-
-			fallbackHashFile, fallbackHashFileErr := os.Open(hashFilePath)
-			if fallbackHashFileErr != nil {
-				logger.Errorf("Could not open hash file %q: %v", hashFilePath, fallbackHashFileErr)
-				fallbackSignatureFile.Close()
-				return "", fallbackHashFileErr
-			}
-
-			verified := checkSignatureOfChecksums(tmpFileRead, fallbackHashFile, fallbackSignatureFile)
-			if !verified {
-				logger.Errorf("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
-				targetFile.Close()
-				os.Remove(targetFile.Name())
-				return "", errors.New("Signature of checksum file could not be verified")
-			}
-		}
+		return true, nil
 	}
 
-	match := checkChecksumMatches(hashFilePath, targetFile)
-	if !match {
-		return "", errors.New("Checksums did not match")
+	logger.Infof("Verifying PGP signature of checksum file: %q", hashFile.Name())
+
+	keyFileContent, err := io.ReadAll(publicKeyFile)
+	if err != nil {
+		return false, fmt.Errorf("Could not read PGP key file %q: %v", publicKeyFile.Name(), err)
 	}
 
-	return zipFilePath, err
+	hashFileContent, err := io.ReadAll(hashFile)
+	if err != nil {
+		return false, fmt.Errorf("Could not read hash file %q: %v", hashFile.Name(), err)
+	}
+
+	signatureContent, err := io.ReadAll(signatureFile)
+	if err != nil {
+		return false, fmt.Errorf("Could not read PGP signature file %q: %v", signatureFile.Name(), err)
+	}
+
+	// Verify signature using key
+	verified := checkSignatureOfChecksums(keyFileContent, hashFileContent, signatureContent)
+	if verified {
+		return true, nil
+	}
+
+	// Fail fast if there is no legacy builtin PGP public key to fall back to
+	if product.GetPublicKeyLegacyLiteral() == "" {
+		return false, errors.New("Signature of checksum file could not be verified and fallback does not exist")
+	}
+
+	legacyBuiltinKeyIdentifier := "legacy builtin PGP public key"
+	logger.Warnf(
+		"Checksum file PGP signature verification failed with public key from %q file. "+
+			"Falling back to %s", publicKeyFile.Name(), legacyBuiltinKeyIdentifier,
+	)
+
+	verified = checkSignatureOfChecksums([]byte(product.GetPublicKeyLegacyLiteral()), hashFileContent, signatureContent)
+	if !verified {
+		logger.Errorf("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
+	}
+	return verified, nil
 }
 
 func downloadFromURL(installLocation string, url string, wg *sync.WaitGroup) (string, error) {
@@ -255,15 +252,4 @@ func downloadPublicKey(product Product, installLocation string, wg *sync.WaitGro
 		}
 	}
 	return pubKeyFilePath, nil
-}
-
-func cleanup(paths []string, wg *sync.WaitGroup) {
-	for _, path := range paths {
-		wg.Add(1)
-		logger.Infof("Deleting %q", path)
-		err := os.Remove(path)
-		if err != nil {
-			logger.Error("Error deleting %q: %v", path, err)
-		}
-	}
 }

--- a/lib/download.go
+++ b/lib/download.go
@@ -19,7 +19,6 @@ func DownloadFromURL(installLocation, mirrorURL, tfversion, versionPrefix, goos,
 	return DownloadProductFromURL(product, installLocation, mirrorURL, tfversion, versionPrefix, goos, goarch)
 }
 
-//nolint:gocyclo
 func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversion, versionPrefix, goos, goarch string) (string, error) {
 	var wg sync.WaitGroup
 	defer wg.Done()
@@ -109,8 +108,7 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	return zipFilePath, err
 }
 
-// verifySignature: Verify signature of hash file.
-// If
+// verifySignature: Verify signature of checksum (hash) file
 func verifySignature(product Product, publicKeyFile, hashFile, signatureFile *os.File) (bool, error) {
 	// CAUTION: Skip PGP signature verification of checksum file if TF_SKIP_SIGNATURE_VERIFICATION
 	// environment variable is set to true-ish value: 1, t, T, TRUE, true, True
@@ -125,7 +123,6 @@ func verifySignature(product Product, publicKeyFile, hashFile, signatureFile *os
 			"Unable to parse \"TF_SKIP_SIGNATURE_VERIFICATION\" env var value %q, defaulting to \"false\"",
 			skipSignatureVerificationStr,
 		)
-		return true, nil
 	}
 
 	if skipSignatureVerification {

--- a/lib/download.go
+++ b/lib/download.go
@@ -129,6 +129,7 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 			tmpFile, err := os.CreateTemp("", "tfswitch.pubkey.asc.*")
 			if err != nil {
 				logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, err)
+				targetFile.Close()
 				os.Remove(targetFile.Name())
 				return "", err
 			}
@@ -138,13 +139,15 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 
 			if _, err := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); err != nil {
 				logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, err)
+				targetFile.Close()
 				os.Remove(targetFile.Name())
 				return "", err
 			}
 
 			tmpFile, err = os.Open(tmpFile.Name())
 			if err != nil {
-				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile, err)
+				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile.Name(), err)
+				targetFile.Close()
 				os.Remove(targetFile.Name())
 				return "", err
 			}
@@ -163,7 +166,8 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 
 			verified := checkSignatureOfChecksums(tmpFile, hashFile, signatureFile)
 			if !verified {
-				logger.Error("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
+				logger.Errorf("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
+				targetFile.Close()
 				os.Remove(targetFile.Name())
 				return "", errors.New("Signature of checksum file could not be verified")
 			}

--- a/lib/download.go
+++ b/lib/download.go
@@ -128,8 +128,8 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 			)
 
 			tmpFile, tmpFileErr := os.CreateTemp("", "tfswitch.pubkey.asc.*")
-			if err != nil {
-				logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, err)
+			if tmpFileErr != nil {
+				logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, tmpFileErr)
 				targetFile.Close()
 				os.Remove(targetFile.Name())
 				return "", tmpFileErr
@@ -139,30 +139,30 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 			defer os.Remove(tmpFile.Name())
 
 			if _, writeStringErr := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); writeStringErr != nil {
-				logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, err)
+				logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, writeStringErr)
 				targetFile.Close()
 				os.Remove(targetFile.Name())
 				return "", writeStringErr
 			}
 
-			tmpFile, err = os.Open(tmpFile.Name())
-			if err != nil {
-				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile.Name(), err)
+			tmpFile, tmpFileErr = os.Open(tmpFile.Name())
+			if tmpFileErr != nil {
+				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile.Name(), tmpFileErr)
 				targetFile.Close()
 				os.Remove(targetFile.Name())
-				return "", err
+				return "", tmpFileErr
 			}
 
-			signatureFile, err := os.Open(hashSigFilePath)
-			if err != nil {
-				logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, err)
-				return "", err
+			signatureFile, signatureFileErr := os.Open(hashSigFilePath)
+			if signatureFileErr != nil {
+				logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, signatureFileErr)
+				return "", signatureFileErr
 			}
 
-			hashFile, err := os.Open(hashFilePath)
-			if err != nil {
-				logger.Errorf("Could not open hash file %q: %v", hashFilePath, err)
-				return "", err
+			hashFile, hashFileErr := os.Open(hashFilePath)
+			if hashFileErr != nil {
+				logger.Errorf("Could not open hash file %q: %v", hashFilePath, hashFileErr)
+				return "", hashFileErr
 			}
 
 			verified := checkSignatureOfChecksums(tmpFile, hashFile, signatureFile)

--- a/lib/download.go
+++ b/lib/download.go
@@ -145,12 +145,12 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 				return "", writeStringErr
 			}
 
-			tmpFile, tmpFileErr = os.Open(tmpFile.Name())
-			if tmpFileErr != nil {
-				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile.Name(), tmpFileErr)
+			tmpFileRead, tmpFileReadErr := os.Open(tmpFile.Name())
+			if tmpFileReadErr != nil {
+				logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile.Name(), tmpFileReadErr)
 				targetFile.Close()
 				os.Remove(targetFile.Name())
-				return "", tmpFileErr
+				return "", tmpFileReadErr
 			}
 
 			fallbackSignatureFile, fallbackSignatureFileErr := os.Open(hashSigFilePath)
@@ -166,7 +166,7 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 				return "", fallbackHashFileErr
 			}
 
-			verified := checkSignatureOfChecksums(tmpFile, fallbackHashFile, fallbackSignatureFile)
+			verified := checkSignatureOfChecksums(tmpFileRead, fallbackHashFile, fallbackSignatureFile)
 			if !verified {
 				logger.Errorf("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
 				targetFile.Close()

--- a/lib/download.go
+++ b/lib/download.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -54,9 +55,6 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 		return "", err
 	}
 
-	// // Wait for wait group, as the file downloads are required for the below functionality
-	// wg.Wait()
-
 	publicKeyFile, err := os.Open(pubKeyFilename)
 	if err != nil {
 		logger.Errorf("Could not open public key %q: %v", pubKeyFilename, err)
@@ -86,14 +84,88 @@ func DownloadProductFromURL(product Product, installLocation, mirrorURL, tfversi
 	filesToCleanup = append(filesToCleanup, hashSigFilePath)
 	defer cleanup(filesToCleanup, &wg)
 
-	verified := checkSignatureOfChecksums(publicKeyFile, hashFile, signatureFile)
-	if !verified {
-		return "", errors.New("Signature of checksum file could not be verified")
+	// CAUTION: Skip PGP signature verification of checksum file if TF_SKIP_SIGNATURE_VERIFICATION
+	// environment variable is set to true-ish value: 1, t, T, TRUE, true, True
+	// THIS IS NOT RECOMMENDED AND SHOULD ONLY BE USED FOR TESTING PURPOSES!
+	skipSignatureVerificationStr, exists := os.LookupEnv("TF_SKIP_SIGNATURE_VERIFICATION")
+	if !exists {
+		skipSignatureVerificationStr = "false"
 	}
+	skipSignatureVerification, err := strconv.ParseBool(skipSignatureVerificationStr)
+	if err != nil {
+		logger.Debugf(
+			"Unable to parse \"TF_SKIP_SIGNATURE_VERIFICATION\" env var value %q, defaulting to \"false\"",
+			skipSignatureVerificationStr,
+		)
+		skipSignatureVerification = false
+	}
+
+	if skipSignatureVerification {
+		logger.Warn(
+			"Skipping PGP signature verification of checksum file due to " +
+				"\"TF_SKIP_SIGNATURE_VERIFICATION\" environment variable being set",
+		)
+		logger.Warn("!!! THIS IS NOT RECOMMENDED AND SHOULD ONLY BE USED FOR TESTING PURPOSES !!!")
+	} else {
+		verified := checkSignatureOfChecksums(publicKeyFile, hashFile, signatureFile)
+		if !verified {
+			if product.GetPublicKeyLegacyLiteral() != "" {
+				legacyBuiltinKeyIdentifier := "legacy builtin PGP public key"
+				logger.Warnf(
+					"Checksum file PGP signature verification failed with public key from %q file. "+
+						"Falling back to %s", pubKeyFilename, legacyBuiltinKeyIdentifier,
+				)
+
+				tmpFile, err := os.CreateTemp("", "tfswitch.pubkey.asc.*")
+				if err != nil {
+					logger.Errorf("Error creating temporary file for %s: %v", legacyBuiltinKeyIdentifier, err)
+					os.Remove(targetFile.Name())
+					return "", err
+				}
+
+				defer tmpFile.Close()
+				defer os.Remove(tmpFile.Name())
+
+				if _, err := tmpFile.WriteString(product.GetPublicKeyLegacyLiteral()); err != nil {
+					logger.Errorf("Error writing %s to temporary file: %v", legacyBuiltinKeyIdentifier, err)
+					os.Remove(targetFile.Name())
+					return "", err
+				}
+
+				tmpFile, err = os.Open(tmpFile.Name())
+				if err != nil {
+					logger.Errorf("Could not open temporary %s file %q: %v", legacyBuiltinKeyIdentifier, tmpFile, err)
+					os.Remove(targetFile.Name())
+					return "", err
+				}
+
+				signatureFile, err := os.Open(hashSigFilePath)
+				if err != nil {
+					logger.Errorf("Could not open hash signature file %q: %v", hashSigFilePath, err)
+					return "", err
+				}
+
+				hashFile, err := os.Open(hashFilePath)
+				if err != nil {
+					logger.Errorf("Could not open hash file %q: %v", hashFilePath, err)
+					return "", err
+				}
+
+				verified := checkSignatureOfChecksums(tmpFile, hashFile, signatureFile)
+				if !verified {
+					logger.Error("Signature of checksum file could not be verified with %s either", legacyBuiltinKeyIdentifier)
+					os.Remove(targetFile.Name())
+					return "", errors.New("Signature of checksum file could not be verified")
+				}
+			}
+		}
+	}
+
 	match := checkChecksumMatches(hashFilePath, targetFile)
 	if !match {
 		return "", errors.New("Checksums did not match")
 	}
+
 	return zipFilePath, err
 }
 

--- a/lib/product.go
+++ b/lib/product.go
@@ -10,16 +10,17 @@ const legacyProductId = "terraform"
 
 // nolint:revive // FIXME: var-naming: struct field PublicKeyId should be PublicKeyID (revive)
 type ProductDetails struct {
-	ID                    string
-	Name                  string
-	DefaultMirror         string
-	VersionPrefix         string
-	DefaultDownloadMirror string
-	ExecutableName        string
-	ArchivePrefix         string
-	PublicKeyId           string
-	PublicKeyURLs         []string
-	FileExtensions        []string
+	ID                     string
+	Name                   string
+	DefaultMirror          string
+	VersionPrefix          string
+	DefaultDownloadMirror  string
+	ExecutableName         string
+	ArchivePrefix          string
+	PublicKeyId            string
+	PublicKeyURLs          []string
+	PublicKeyLegacyLiteral string
+	FileExtensions         []string
 }
 
 type TerraformProduct struct {
@@ -42,6 +43,7 @@ type Product interface {
 	GetArchivePrefix() string
 	GetPublicKeyId() string
 	GetPublicKeyURLs() []string
+	GetPublicKeyLegacyLiteral() string
 	GetShaSignatureSuffix() string
 	GetArtifactUrl(mirrorURL string, version string) string
 	GetRecentVersionProduct(recentFile *RecentFile) []string
@@ -89,6 +91,10 @@ func (p TerraformProduct) GetPublicKeyId() string {
 
 func (p TerraformProduct) GetPublicKeyURLs() []string {
 	return p.PublicKeyURLs
+}
+
+func (p TerraformProduct) GetPublicKeyLegacyLiteral() string {
+	return p.PublicKeyLegacyLiteral
 }
 
 func (p TerraformProduct) GetShaSignatureSuffix() string {
@@ -149,6 +155,10 @@ func (p OpenTofuProduct) GetPublicKeyURLs() []string {
 	return p.PublicKeyURLs
 }
 
+func (p OpenTofuProduct) GetPublicKeyLegacyLiteral() string {
+	return p.PublicKeyLegacyLiteral
+}
+
 func (p OpenTofuProduct) GetShaSignatureSuffix() string {
 	return "gpgsig"
 }
@@ -177,21 +187,145 @@ var products = []Product{
 			ArchivePrefix:  "terraform_",
 			PublicKeyId:    "72D7468F",
 			PublicKeyURLs:  []string{"https://www.hashicorp.com/.well-known/pgp-key.txt", "https://keybase.io/hashicorp/pgp_keys.asc"},
+			PublicKeyLegacyLiteral: "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+				"Comment: https://www.hashicorp.com/.well-known/pgp-key-old.txt\n" +
+				"\n" +
+				"mQINBGB9+xkBEACabYZOWKmgZsHTdRDiyPJxhbuUiKX65GUWkyRMJKi/1dviVxOX\n" +
+				"PG6hBPtF48IFnVgxKpIb7G6NjBousAV+CuLlv5yqFKpOZEGC6sBV+Gx8Vu1CICpl\n" +
+				"Zm+HpQPcIzwBpN+Ar4l/exCG/f/MZq/oxGgH+TyRF3XcYDjG8dbJCpHO5nQ5Cy9h\n" +
+				"QIp3/Bh09kET6lk+4QlofNgHKVT2epV8iK1cXlbQe2tZtfCUtxk+pxvU0UHXp+AB\n" +
+				"0xc3/gIhjZp/dePmCOyQyGPJbp5bpO4UeAJ6frqhexmNlaw9Z897ltZmRLGq1p4a\n" +
+				"RnWL8FPkBz9SCSKXS8uNyV5oMNVn4G1obCkc106iWuKBTibffYQzq5TG8FYVJKrh\n" +
+				"RwWB6piacEB8hl20IIWSxIM3J9tT7CPSnk5RYYCTRHgA5OOrqZhC7JefudrP8n+M\n" +
+				"pxkDgNORDu7GCfAuisrf7dXYjLsxG4tu22DBJJC0c/IpRpXDnOuJN1Q5e/3VUKKW\n" +
+				"mypNumuQpP5lc1ZFG64TRzb1HR6oIdHfbrVQfdiQXpvdcFx+Fl57WuUraXRV6qfb\n" +
+				"4ZmKHX1JEwM/7tu21QE4F1dz0jroLSricZxfaCTHHWNfvGJoZ30/MZUrpSC0IfB3\n" +
+				"iQutxbZrwIlTBt+fGLtm3vDtwMFNWM+Rb1lrOxEQd2eijdxhvBOHtlIcswARAQAB\n" +
+				"tERIYXNoaUNvcnAgU2VjdXJpdHkgKGhhc2hpY29ycC5jb20vc2VjdXJpdHkpIDxz\n" +
+				"ZWN1cml0eUBoYXNoaWNvcnAuY29tPokCVAQTAQoAPhYhBMh0AR8KtAURDQIQVTQ2\n" +
+				"XZRy10aPBQJgffsZAhsDBQkJZgGABQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAAAoJ\n" +
+				"EDQ2XZRy10aPtpcP/0PhJKiHtC1zREpRTrjGizoyk4Sl2SXpBZYhkdrG++abo6zs\n" +
+				"buaAG7kgWWChVXBo5E20L7dbstFK7OjVs7vAg/OLgO9dPD8n2M19rpqSbbvKYWvp\n" +
+				"0NSgvFTT7lbyDhtPj0/bzpkZEhmvQaDWGBsbDdb2dBHGitCXhGMpdP0BuuPWEix+\n" +
+				"QnUMaPwU51q9GM2guL45Tgks9EKNnpDR6ZdCeWcqo1IDmklloidxT8aKL21UOb8t\n" +
+				"cD+Bg8iPaAr73bW7Jh8TdcV6s6DBFub+xPJEB/0bVPmq3ZHs5B4NItroZ3r+h3ke\n" +
+				"VDoSOSIZLl6JtVooOJ2la9ZuMqxchO3mrXLlXxVCo6cGcSuOmOdQSz4OhQE5zBxx\n" +
+				"LuzA5ASIjASSeNZaRnffLIHmht17BPslgNPtm6ufyOk02P5XXwa69UCjA3RYrA2P\n" +
+				"QNNC+OWZ8qQLnzGldqE4MnRNAxRxV6cFNzv14ooKf7+k686LdZrP/3fQu2p3k5rY\n" +
+				"0xQUXKh1uwMUMtGR867ZBYaxYvwqDrg9XB7xi3N6aNyNQ+r7zI2lt65lzwG1v9hg\n" +
+				"FG2AHrDlBkQi/t3wiTS3JOo/GCT8BjN0nJh0lGaRFtQv2cXOQGVRW8+V/9IpqEJ1\n" +
+				"qQreftdBFWxvH7VJq2mSOXUJyRsoUrjkUuIivaA9Ocdipk2CkP8bpuGz7ZF4uQIN\n" +
+				"BGB9+xkBEACoklYsfvWRCjOwS8TOKBTfl8myuP9V9uBNbyHufzNETbhYeT33Cj0M\n" +
+				"GCNd9GdoaknzBQLbQVSQogA+spqVvQPz1MND18GIdtmr0BXENiZE7SRvu76jNqLp\n" +
+				"KxYALoK2Pc3yK0JGD30HcIIgx+lOofrVPA2dfVPTj1wXvm0rbSGA4Wd4Ng3d2AoR\n" +
+				"G/wZDAQ7sdZi1A9hhfugTFZwfqR3XAYCk+PUeoFrkJ0O7wngaon+6x2GJVedVPOs\n" +
+				"2x/XOR4l9ytFP3o+5ILhVnsK+ESVD9AQz2fhDEU6RhvzaqtHe+sQccR3oVLoGcat\n" +
+				"ma5rbfzH0Fhj0JtkbP7WreQf9udYgXxVJKXLQFQgel34egEGG+NlbGSPG+qHOZtY\n" +
+				"4uWdlDSvmo+1P95P4VG/EBteqyBbDDGDGiMs6lAMg2cULrwOsbxWjsWka8y2IN3z\n" +
+				"1stlIJFvW2kggU+bKnQ+sNQnclq3wzCJjeDBfucR3a5WRojDtGoJP6Fc3luUtS7V\n" +
+				"5TAdOx4dhaMFU9+01OoH8ZdTRiHZ1K7RFeAIslSyd4iA/xkhOhHq89F4ECQf3Bt4\n" +
+				"ZhGsXDTaA/VgHmf3AULbrC94O7HNqOvTWzwGiWHLfcxXQsr+ijIEQvh6rHKmJK8R\n" +
+				"9NMHqc3L18eMO6bqrzEHW0Xoiu9W8Yj+WuB3IKdhclT3w0pO4Pj8gQARAQABiQI8\n" +
+				"BBgBCgAmFiEEyHQBHwq0BRENAhBVNDZdlHLXRo8FAmB9+xkCGwwFCQlmAYAACgkQ\n" +
+				"NDZdlHLXRo9ZnA/7BmdpQLeTjEiXEJyW46efxlV1f6THn9U50GWcE9tebxCXgmQf\n" +
+				"u+Uju4hreltx6GDi/zbVVV3HCa0yaJ4JVvA4LBULJVe3ym6tXXSYaOfMdkiK6P1v\n" +
+				"JgfpBQ/b/mWB0yuWTUtWx18BQQwlNEQWcGe8n1lBbYsH9g7QkacRNb8tKUrUbWlQ\n" +
+				"QsU8wuFgly22m+Va1nO2N5C/eE/ZEHyN15jEQ+QwgQgPrK2wThcOMyNMQX/VNEr1\n" +
+				"Y3bI2wHfZFjotmek3d7ZfP2VjyDudnmCPQ5xjezWpKbN1kvjO3as2yhcVKfnvQI5\n" +
+				"P5Frj19NgMIGAp7X6pF5Csr4FX/Vw316+AFJd9Ibhfud79HAylvFydpcYbvZpScl\n" +
+				"7zgtgaXMCVtthe3GsG4gO7IdxxEBZ/Fm4NLnmbzCIWOsPMx/FxH06a539xFq/1E2\n" +
+				"1nYFjiKg8a5JFmYU/4mV9MQs4bP/3ip9byi10V+fEIfp5cEEmfNeVeW5E7J8PqG9\n" +
+				"t4rLJ8FR4yJgQUa2gs2SNYsjWQuwS/MJvAv4fDKlkQjQmYRAOp1SszAnyaplvri4\n" +
+				"ncmfDsf0r65/sd6S40g5lHH8LIbGxcOIN6kwthSTPWX89r42CbY8GzjTkaeejNKx\n" +
+				"v1aCrO58wAtursO1DiXCvBY7+NdafMRnoHwBk50iPqrVkNA8fv+auRyB2/G5Ag0E\n" +
+				"YH3+JQEQALivllTjMolxUW2OxrXb+a2Pt6vjCBsiJzrUj0Pa63U+lT9jldbCCfgP\n" +
+				"wDpcDuO1O05Q8k1MoYZ6HddjWnqKG7S3eqkV5c3ct3amAXp513QDKZUfIDylOmhU\n" +
+				"qvxjEgvGjdRjz6kECFGYr6Vnj/p6AwWv4/FBRFlrq7cnQgPynbIH4hrWvewp3Tqw\n" +
+				"GVgqm5RRofuAugi8iZQVlAiQZJo88yaztAQ/7VsXBiHTn61ugQ8bKdAsr8w/ZZU5\n" +
+				"HScHLqRolcYg0cKN91c0EbJq9k1LUC//CakPB9mhi5+aUVUGusIM8ECShUEgSTCi\n" +
+				"KQiJUPZ2CFbbPE9L5o9xoPCxjXoX+r7L/WyoCPTeoS3YRUMEnWKvc42Yxz3meRb+\n" +
+				"BmaqgbheNmzOah5nMwPupJYmHrjWPkX7oyyHxLSFw4dtoP2j6Z7GdRXKa2dUYdk2\n" +
+				"x3JYKocrDoPHh3Q0TAZujtpdjFi1BS8pbxYFb3hHmGSdvz7T7KcqP7ChC7k2RAKO\n" +
+				"GiG7QQe4NX3sSMgweYpl4OwvQOn73t5CVWYp/gIBNZGsU3Pto8g27vHeWyH9mKr4\n" +
+				"cSepDhw+/X8FGRNdxNfpLKm7Vc0Sm9Sof8TRFrBTqX+vIQupYHRi5QQCuYaV6OVr\n" +
+				"ITeegNK3So4m39d6ajCR9QxRbmjnx9UcnSYYDmIB6fpBuwT0ogNtABEBAAGJBHIE\n" +
+				"GAEKACYCGwIWIQTIdAEfCrQFEQ0CEFU0Nl2UctdGjwUCYH4bgAUJAeFQ2wJAwXQg\n" +
+				"BBkBCgAdFiEEs2y6kaLAcwxDX8KAsLRBCXaFtnYFAmB9/iUACgkQsLRBCXaFtnYX\n" +
+				"BhAAlxejyFXoQwyGo9U+2g9N6LUb/tNtH29RHYxy4A3/ZUY7d/FMkArmh4+dfjf0\n" +
+				"p9MJz98Zkps20kaYP+2YzYmaizO6OA6RIddcEXQDRCPHmLts3097mJ/skx9qLAf6\n" +
+				"rh9J7jWeSqWO6VW6Mlx8j9m7sm3Ae1OsjOx/m7lGZOhY4UYfY627+Jf7WQ5103Qs\n" +
+				"lgQ09es/vhTCx0g34SYEmMW15Tc3eCjQ21b1MeJD/V26npeakV8iCZ1kHZHawPq/\n" +
+				"aCCuYEcCeQOOteTWvl7HXaHMhHIx7jjOd8XX9V+UxsGz2WCIxX/j7EEEc7CAxwAN\n" +
+				"nWp9jXeLfxYfjrUB7XQZsGCd4EHHzUyCf7iRJL7OJ3tz5Z+rOlNjSgci+ycHEccL\n" +
+				"YeFAEV+Fz+sj7q4cFAferkr7imY1XEI0Ji5P8p/uRYw/n8uUf7LrLw5TzHmZsTSC\n" +
+				"UaiL4llRzkDC6cVhYfqQWUXDd/r385OkE4oalNNE+n+txNRx92rpvXWZ5qFYfv7E\n" +
+				"95fltvpXc0iOugPMzyof3lwo3Xi4WZKc1CC/jEviKTQhfn3WZukuF5lbz3V1PQfI\n" +
+				"xFsYe9WYQmp25XGgezjXzp89C/OIcYsVB1KJAKihgbYdHyUN4fRCmOszmOUwEAKR\n" +
+				"3k5j4X8V5bk08sA69NVXPn2ofxyk3YYOMYWW8ouObnXoS8QJEDQ2XZRy10aPMpsQ\n" +
+				"AIbwX21erVqUDMPn1uONP6o4NBEq4MwG7d+fT85rc1U0RfeKBwjucAE/iStZDQoM\n" +
+				"ZKWvGhFR+uoyg1LrXNKuSPB82unh2bpvj4zEnJsJadiwtShTKDsikhrfFEK3aCK8\n" +
+				"Zuhpiu3jxMFDhpFzlxsSwaCcGJqcdwGhWUx0ZAVD2X71UCFoOXPjF9fNnpy80YNp\n" +
+				"flPjj2RnOZbJyBIM0sWIVMd8F44qkTASf8K5Qb47WFN5tSpePq7OCm7s8u+lYZGK\n" +
+				"wR18K7VliundR+5a8XAOyUXOL5UsDaQCK4Lj4lRaeFXunXl3DJ4E+7BKzZhReJL6\n" +
+				"EugV5eaGonA52TWtFdB8p+79wPUeI3KcdPmQ9Ll5Zi/jBemY4bzasmgKzNeMtwWP\n" +
+				"fk6WgrvBwptqohw71HDymGxFUnUP7XYYjic2sVKhv9AevMGycVgwWBiWroDCQ9Ja\n" +
+				"btKfxHhI2p+g+rcywmBobWJbZsujTNjhtme+kNn1mhJsD3bKPjKQfAxaTskBLb0V\n" +
+				"wgV21891TS1Dq9kdPLwoS4XNpYg2LLB4p9hmeG3fu9+OmqwY5oKXsHiWc43dei9Y\n" +
+				"yxZ1AAUOIaIdPkq+YG/PhlGE4YcQZ4RPpltAr0HfGgZhmXWigbGS+66pUj+Ojysc\n" +
+				"j0K5tCVxVu0fhhFpOlHv0LWaxCbnkgkQH9jfMEJkAWMOuQINBGCAXCYBEADW6RNr\n" +
+				"ZVGNXvHVBqSiOWaxl1XOiEoiHPt50Aijt25yXbG+0kHIFSoR+1g6Lh20JTCChgfQ\n" +
+				"kGGjzQvEuG1HTw07YhsvLc0pkjNMfu6gJqFox/ogc53mz69OxXauzUQ/TZ27GDVp\n" +
+				"UBu+EhDKt1s3OtA6Bjz/csop/Um7gT0+ivHyvJ/jGdnPEZv8tNuSE/Uo+hn/Q9hg\n" +
+				"8SbveZzo3C+U4KcabCESEFl8Gq6aRi9vAfa65oxD5jKaIz7cy+pwb0lizqlW7H9t\n" +
+				"Qlr3dBfdIcdzgR55hTFC5/XrcwJ6/nHVH/xGskEasnfCQX8RYKMuy0UADJy72TkZ\n" +
+				"bYaCx+XXIcVB8GTOmJVoAhrTSSVLAZspfCnjwnSxisDn3ZzsYrq3cV6sU8b+QlIX\n" +
+				"7VAjurE+5cZiVlaxgCjyhKqlGgmonnReWOBacCgL/UvuwMmMp5TTLmiLXLT7uxeG\n" +
+				"ojEyoCk4sMrqrU1jevHyGlDJH9Taux15GILDwnYFfAvPF9WCid4UZ4Ouwjcaxfys\n" +
+				"3LxNiZIlUsXNKwS3mhiMRL4TRsbs4k4QE+LIMOsauIvcvm8/frydvQ/kUwIhVTH8\n" +
+				"0XGOH909bYtJvY3fudK7ShIwm7ZFTduBJUG473E/Fn3VkhTmBX6+PjOC50HR/Hyb\n" +
+				"waRCzfDruMe3TAcE/tSP5CUOb9C7+P+hPzQcDwARAQABiQRyBBgBCgAmFiEEyHQB\n" +
+				"Hwq0BRENAhBVNDZdlHLXRo8FAmCAXCYCGwIFCQlmAYACQAkQNDZdlHLXRo/BdCAE\n" +
+				"GQEKAB0WIQQ3TsdbSFkTYEqDHMfIIMbVzSerhwUCYIBcJgAKCRDIIMbVzSerh0Xw\n" +
+				"D/9ghnUsoNCu1OulcoJdHboMazJvDt/znttdQSnULBVElgM5zk0Uyv87zFBzuCyQ\n" +
+				"JWL3bWesQ2uFx5fRWEPDEfWVdDrjpQGb1OCCQyz1QlNPV/1M1/xhKGS9EeXrL8Dw\n" +
+				"F6KTGkRwn1yXiP4BGgfeFIQHmJcKXEZ9HkrpNb8mcexkROv4aIPAwn+IaE+NHVtt\n" +
+				"IBnufMXLyfpkWJQtJa9elh9PMLlHHnuvnYLvuAoOkhuvs7fXDMpfFZ01C+QSv1dz\n" +
+				"Hm52GSStERQzZ51w4c0rYDneYDniC/sQT1x3dP5Xf6wzO+EhRMabkvoTbMqPsTEP\n" +
+				"xyWr2pNtTBYp7pfQjsHxhJpQF0xjGN9C39z7f3gJG8IJhnPeulUqEZjhRFyVZQ6/\n" +
+				"siUeq7vu4+dM/JQL+i7KKe7Lp9UMrG6NLMH+ltaoD3+lVm8fdTUxS5MNPoA/I8cK\n" +
+				"1OWTJHkrp7V/XaY7mUtvQn5V1yET5b4bogz4nME6WLiFMd+7x73gB+YJ6MGYNuO8\n" +
+				"e/NFK67MfHbk1/AiPTAJ6s5uHRQIkZcBPG7y5PpfcHpIlwPYCDGYlTajZXblyKrw\n" +
+				"BttVnYKvKsnlysv11glSg0DphGxQJbXzWpvBNyhMNH5dffcfvd3eXJAxnD81GD2z\n" +
+				"ZAriMJ4Av2TfeqQ2nxd2ddn0jX4WVHtAvLXfCgLM2Gveho4jD/9sZ6PZz/rEeTvt\n" +
+				"h88t50qPcBa4bb25X0B5FO3TeK2LL3VKLuEp5lgdcHVonrcdqZFobN1CgGJua8TW\n" +
+				"SprIkh+8ATZ/FXQTi01NzLhHXT1IQzSpFaZw0gb2f5ruXwvTPpfXzQrs2omY+7s7\n" +
+				"fkCwGPesvpSXPKn9v8uhUwD7NGW/Dm+jUM+QtC/FqzX7+/Q+OuEPjClUh1cqopCZ\n" +
+				"EvAI3HjnavGrYuU6DgQdjyGT/UDbuwbCXqHxHojVVkISGzCTGpmBcQYQqhcFRedJ\n" +
+				"yJlu6PSXlA7+8Ajh52oiMJ3ez4xSssFgUQAyOB16432tm4erpGmCyakkoRmMUn3p\n" +
+				"wx+QIppxRlsHznhcCQKR3tcblUqH3vq5i4/ZAihusMCa0YrShtxfdSb13oKX+pFr\n" +
+				"aZXvxyZlCa5qoQQBV1sowmPL1N2j3dR9TVpdTyCFQSv4KeiExmowtLIjeCppRBEK\n" +
+				"eeYHJnlfkyKXPhxTVVO6H+dU4nVu0ASQZ07KiQjbI+zTpPKFLPp3/0sPRJM57r1+\n" +
+				"aTS71iR7nZNZ1f8LZV2OvGE6fJVtgJ1J4Nu02K54uuIhU3tg1+7Xt+IqwRc9rbVr\n" +
+				"pHH/hFCYBPW2D2dxB+k2pQlg5NI+TpsXj5Zun8kRw5RtVb+dLuiH/xmxArIee8Jq\n" +
+				"ZF5q4h4I33PSGDdSvGXn9UMY5Isjpg==\n" +
+				"=7pIB\n" +
+				"-----END PGP PUBLIC KEY BLOCK-----\n",
 			FileExtensions: []string{"tf"},
 		},
 	},
 	OpenTofuProduct{
 		ProductDetails{
-			ID:                    "opentofu",
-			Name:                  "OpenTofu",
-			DefaultMirror:         "https://get.opentofu.org/tofu",
-			DefaultDownloadMirror: "https://github.com/opentofu/opentofu/releases/download",
-			VersionPrefix:         "opentofu_",
-			ExecutableName:        "tofu",
-			ArchivePrefix:         "tofu_",
-			PublicKeyId:           "0C0AF313E5FD9F80",
-			PublicKeyURLs:         []string{"https://get.opentofu.org/opentofu.asc"},
-			FileExtensions:        []string{"tf", "tofu"},
+			ID:                     "opentofu",
+			Name:                   "OpenTofu",
+			DefaultMirror:          "https://get.opentofu.org/tofu",
+			DefaultDownloadMirror:  "https://github.com/opentofu/opentofu/releases/download",
+			VersionPrefix:          "opentofu_",
+			ExecutableName:         "tofu",
+			ArchivePrefix:          "tofu_",
+			PublicKeyId:            "0C0AF313E5FD9F80",
+			PublicKeyURLs:          []string{"https://get.opentofu.org/opentofu.asc"},
+			PublicKeyLegacyLiteral: "",
+			FileExtensions:         []string{"tf", "tofu"},
 		},
 	},
 }

--- a/lib/product_test.go
+++ b/lib/product_test.go
@@ -116,6 +116,13 @@ func Test_GetPublicKeyURLs_Terraform(t *testing.T) {
 	}
 }
 
+func Test_GetPublicKeyLegacyLiteral_Terraform(t *testing.T) {
+	product := GetProductById("terraform")
+	if product.GetPublicKeyLegacyLiteral() == "" {
+		t.Error("Product GetPublicKeyLegacyLiteral is empty")
+	}
+}
+
 func Test_GetShaSignatureSuffix_Terraform(t *testing.T) {
 	product := GetProductById("terraform")
 	actual := product.GetShaSignatureSuffix()
@@ -230,6 +237,13 @@ func Test_GetPublicKeyUrl_OpenTofu(t *testing.T) {
 	actual := product.GetPublicKeyURLs()
 	if !slices.Equal(expected, actual) {
 		t.Errorf("Product GetPublicKeyURLs does not match expected ID. Expected: %q, actual: %q", strings.Join(expected, ","), strings.Join(actual, ","))
+	}
+}
+
+func Test_GetPublicKeyLegacyLiteral_OpenTofu(t *testing.T) {
+	product := GetProductById("opentofu")
+	if product.GetPublicKeyLegacyLiteral() != "" {
+		t.Error("Product GetPublicKeyLegacyLiteral is NOT empty")
 	}
 }
 

--- a/lib/product_test.go
+++ b/lib/product_test.go
@@ -26,7 +26,7 @@ func Test_GetProductById(t *testing.T) {
 		}
 	}
 
-	// Test case-insensitve match
+	// Test case-insensitive match
 	product = GetProductById("oPeNtOfU")
 	if product == nil {
 		t.Errorf("Terraform product returned nil")

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -19,13 +19,6 @@ func FileExistsAndIsNotDir(filename string) bool {
 	return !info.IsDir()
 }
 
-func closeFileHandlers(handlers []*os.File) {
-	for _, handler := range handlers {
-		logger.Debugf("Closing file handler %q", handler.Name())
-		_ = handler.Close()
-	}
-}
-
 func UsageMessage() {
 	getopt.PrintUsage(os.Stderr)
 }


### PR DESCRIPTION
Fixes #746
Relates to #747, $749

Fallback to builtin legacy PGP public key if modern key fails verification.

See https://github.com/warrensbox/terraform-switcher/issues/746#issuecomment-4291666295
> We unfortunately had to revert this change because several downstream clients couldn't handle multiple key blocks in a file. hashicorp.com/.well-known/pgp-key.txt serves the new key, and the old, now expired public key is available at hashicorp.com/.well-known/pgp-key-old.txt

See https://github.com/warrensbox/terraform-switcher/issues/746#issuecomment-4291895492
> Hmm, the hashicorp.com/.well-known/pgp-key-old.txt seems to not be available just like that 🤦🏻 I can download it via GUI browser, but programmatical approach via CLI just fails unexpectedly 😕