### PR TITLE
feat(opentofu): Switch artifact download from GitHub Releases to OpenTofu's site

### DIFF
--- a/lib/product.go
+++ b/lib/product.go
@@ -180,11 +180,17 @@ func (p OpenTofuProduct) GetArchivePrefix() string {
 	return p.ArchivePrefix
 }
 
-// nolint:revive // FIXME: parameter 'mirrorURL' is not used (custom Mirror URL is not implemented for OpenTofu? 10-Mar-2025)
 // nolint:revive // FIXME: var-naming: method GetArtifactUrl should be GetArtifactURL (revive)
-// @TODO For a future release, use user-provided mirror, as we ONLY allow downloading via public OpenTofu URL
 func (p OpenTofuProduct) GetArtifactUrl(mirrorURL string, version string) string {
-	return fmt.Sprintf("%s/v%s", p.DefaultDownloadMirror, version)
+	downloadUrl := p.DefaultDownloadMirror
+
+	// If the actual mirror is not the default, use this mirror for downloading
+	if mirrorURL != p.DefaultMirror {
+		downloadUrl = mirrorURL
+	}
+
+	downloadUrl = strings.TrimRight(downloadUrl, "/")
+	return fmt.Sprintf("%s/%s", downloadUrl, version)
 }
 
 // nolint:revive // FIXME: var-naming: method GetPublicKeyId should be GetPublicKeyID (revive)
@@ -373,7 +379,7 @@ var products = []Product{
 			ID:                     "opentofu",
 			Name:                   "OpenTofu",
 			DefaultMirror:          "https://get.opentofu.org/tofu/api.json",
-			DefaultDownloadMirror:  "https://github.com/opentofu/opentofu/releases/download",
+			DefaultDownloadMirror:  "https://get.opentofu.org/tofu/",
 			VersionPrefix:          "opentofu_",
 			ExecutableName:         "tofu",
 			ArchivePrefix:          "tofu_",

--- a/lib/product_test.go
+++ b/lib/product_test.go
@@ -224,9 +224,10 @@ func Test_GetArchivePrefix_OpenTofu(t *testing.T) {
 }
 
 func Test_GetArtifactUrl_OpenTofu(t *testing.T) {
+	mirrorURL := "https://example.com/opentofu/"
 	product := GetProductById("opentofu")
-	actual := product.GetArtifactUrl("https://example.com/opentofu", "random-meaningless-value")
-	if expected := "https://github.com/opentofu/opentofu/releases/download/vrandom-meaningless-value"; actual != expected {
+	actual := product.GetArtifactUrl(mirrorURL, "random-meaningless-value")
+	if expected := mirrorURL + "random-meaningless-value"; actual != expected {
 		t.Errorf("Product GetArtifactUrl match failed. Expected: %q, actual: %q", expected, actual)
 	}
 }
@@ -234,7 +235,7 @@ func Test_GetArtifactUrl_OpenTofu(t *testing.T) {
 func Test_GetArtifactUrl_OpenTofu_DefaultMirror(t *testing.T) {
 	product := GetProductById("opentofu")
 	actual := product.GetArtifactUrl(product.GetDefaultMirrorUrl(), "random-meaningless-value")
-	if expected := "https://github.com/opentofu/opentofu/releases/download/vrandom-meaningless-value"; actual != expected {
+	if expected := "https://get.opentofu.org/tofu/random-meaningless-value"; actual != expected {
 		t.Errorf("Product GetArtifactUrl match failed. Expected: %q, actual: %q", expected, actual)
 	}
 }


### PR DESCRIPTION
Resolves #744

Switch OpenTofu artifact download (`DefaultDownloadMirror`) from GitHub Releases (https://github.com/opentofu/opentofu/releases/download) to OpenTofu's own site (https://get.opentofu.org/tofu/) to align with Terraform side of things.

---

⛔ **NO GO**: the https://get.opentofu.org/tofu/ doesn't host artifacts — it just lists versions and points to GitHub Releases 🤷🏻 
```shell
> curl -Ss https://get.opentofu.org/tofu/1.11.6/| fgrep -m 5 '<a href='
        <a href="/tofu/">../</a>
            <a href="https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_386.apk">tofu_1.11.6_386.apk</a>
            <a href="https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_386.apk.gpgsig">tofu_1.11.6_386.apk.gpgsig</a>
            <a href="https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_386.apk.pem">tofu_1.11.6_386.apk.pem</a>
            <a href="https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_386.apk.sig">tofu_1.11.6_386.apk.sig</a>
```
ℹ️ Closing as meaningless.