### PR TITLE
feat(mirror): support `file://` schema for the mirror URL

### DIFF
--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"reflect"
 	"regexp"
 	"slices"
@@ -168,6 +169,14 @@ func getTFLatestImplicit(product Product, mirrorURL string, preRelease bool, req
 
 // getTFURLBody : Get list of versions from the mirror URL
 func getTFURLBody(mirrorURL string) (string, error) {
+	// Local file mirror: read the version list straight off disk instead of
+	// fetching it over HTTP. Useful for air-gapped environments where no HTTP
+	// mirror is reachable. The file is expected to contain the same JSON (or
+	// HTML directory listing) that an HTTP mirror would serve.
+	if strings.HasPrefix(mirrorURL, "file://") {
+		return getTFFileBody(mirrorURL)
+	}
+
 	hasSlash := strings.HasSuffix(mirrorURL, "/")
 	isJSON := strings.HasSuffix(mirrorURL, ".json")
 	if !hasSlash && !isJSON {
@@ -192,6 +201,18 @@ func getTFURLBody(mirrorURL string) (string, error) {
 	bodyString := string(body)
 
 	return bodyString, nil
+}
+
+// getTFFileBody : Read the version list from a local `file://` mirror URL.
+// Unlike the HTTP path, a missing or unreadable file returns an error rather
+// than terminating the process, so callers can surface a clear failure.
+func getTFFileBody(mirrorURL string) (string, error) {
+	filePath := strings.TrimPrefix(mirrorURL, "file://")
+	body, errBody := os.ReadFile(filePath) // nolint:gosec // `filePath' is expected to be variable
+	if errBody != nil {
+		return "", fmt.Errorf("Error reading version list from file %q: %v", filePath, errBody)
+	}
+	return string(body), nil
 }
 
 // versionExist : Check if requested version exists

--- a/lib/list_versions_test.go
+++ b/lib/list_versions_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -372,6 +374,57 @@ func TestGetTFURLBody(t *testing.T) {
 	}
 	if body != hashicorpBody {
 		t.Errorf("Body not returned correctly. Expected: %s, actual: %s", hashicorpBody, body)
+	}
+}
+
+// TestGetTFURLBody_File : Test getTFURLBody reads from a local file:// mirror
+func TestGetTFURLBody_File(t *testing.T) {
+	logger = InitLogger("DEBUG")
+
+	tempDir := t.TempDir()
+	versionFile := filepath.Join(tempDir, "index.json")
+	if err := os.WriteFile(versionFile, []byte(hashicorpJSONData), 0o600); err != nil {
+		t.Fatalf("Could not write version list fixture: %v", err)
+	}
+
+	body, err := getTFURLBody("file://" + versionFile)
+	if err != nil {
+		t.Errorf("Unexpected error reading file:// mirror: %v", err)
+	}
+	if body != hashicorpJSONData {
+		t.Errorf("Body not returned correctly. Expected: %s, actual: %s", hashicorpJSONData, body)
+	}
+}
+
+// TestGetTFURLBody_FileMissing : Test getTFURLBody returns an error (rather
+// than terminating the process) when a file:// mirror points at a missing file
+func TestGetTFURLBody_FileMissing(t *testing.T) {
+	logger = InitLogger("DEBUG")
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	_, err := getTFURLBody("file://" + missing)
+	if err == nil {
+		t.Error("Expected an error for a missing file:// mirror, got nil")
+	}
+}
+
+// TestGetTFList_File : Test getTFList resolves versions end-to-end from a
+// local file:// mirror
+func TestGetTFList_File(t *testing.T) {
+	logger = InitLogger("DEBUG")
+
+	tempDir := t.TempDir()
+	versionFile := filepath.Join(tempDir, "index.json")
+	if err := os.WriteFile(versionFile, []byte(hashicorpJSONData), 0o600); err != nil {
+		t.Fatalf("Could not write version list fixture: %v", err)
+	}
+
+	list, err := getTFList(GetProductById("terraform"), "file://"+versionFile, true)
+	if err != nil {
+		t.Errorf("Unexpected error listing versions from file:// mirror: %v", err)
+	}
+	if !slices.Contains(list, "0.12.2") {
+		t.Errorf("Expected version list from file:// mirror to contain 0.12.2, got: %v", list)
 	}
 }
 

--- a/www/docs/usage/commandline.md
+++ b/www/docs/usage/commandline.md
@@ -89,6 +89,24 @@ the mirror root, matching that same layout.
 tfswitch --mirror https://example.jfrog.io/artifactory/hashicorp
 ```
 
+### Local file mirror
+
+The version list can also be read from a local file using a `file://` URL. This
+is useful in air-gapped environments where no HTTP mirror is reachable: generate
+the version list ahead of time and point `tfswitch` at the file on disk.
+
+```bash
+tfswitch --mirror file:///opt/tfswitch/index.json
+```
+
+The file must contain the same content an HTTP mirror would serve — either the
+JSON index (e.g. the body of `<https://releases.hashicorp.com/terraform/index.json>`)
+or the HTML directory listing. A missing or unreadable file causes `tfswitch` to
+exit with an error rather than silently producing an empty version list.
+
+This affects only how the list of available versions is resolved; the binaries
+themselves are still downloaded over HTTP from the mirror's archive tree.
+
 ## Install to non-default location
 
 By default `tfswitch` will download the Terraform binary to the user home


### PR DESCRIPTION
## Summary

Allow `--mirror` to point at a local file via a `file://` URL, so the list of available versions can be resolved from disk instead of over HTTP.

This enables version resolution in **air-gapped environments** where `releases.hashicorp.com` (or any HTTP mirror) is unreachable. The version list can be generated ahead of time and dropped on disk, then `tfswitch` resolves `required_version` constraints against it offline.

```bash
tfswitch --mirror file:///opt/tfswitch/index.json
```

## What changed

- `getTFURLBody` branches on the `file://` scheme and reads the file directly via a new `getTFFileBody` helper.
- The file is expected to contain the same content an HTTP mirror would serve — either the JSON index (e.g. the body of `https://releases.hashicorp.com/terraform/index.json`) or the HTML directory listing. It flows through the existing JSON-then-HTML parsing unchanged.
- Docs: added a "Local file mirror" subsection under the existing custom-mirror documentation.

## Scope

This affects **only how the version list is resolved**. Binary downloads are unchanged and still occur over HTTP from the mirror's archive tree. (Offline binary download is a larger, separate change — it relates to the download-mirror separation discussed in #745 — and is intentionally out of scope here.)

## Tests

- `TestGetTFURLBody_File` — reads the version list from a `file://` URL.
- `TestGetTFURLBody_FileMissing` — a missing file returns an error rather than terminating the process.
- `TestGetTFList_File` — end-to-end version resolution through `getTFList` from a local file.

All `lib` and `lib/param_parsing` tests pass; `go vet` and `go build` are clean.

## Note for reviewers

The `file://` path returns an error on a missing/unreadable file, rather than following the HTTP path's existing `logger.Fatalf` convention. This is intentional: `getTFList` already propagates returned errors, it keeps the function testable, and it surfaces a clear failure instead of an empty version list. Happy to switch to `Fatalf` if you'd prefer consistency with the surrounding code.