### PR TITLE
docs: add troubleshooting entry for stale HashiCorp PGP key cache

### DIFF
--- a/www/docs/Troubleshoot.md
+++ b/www/docs/Troubleshoot.md
@@ -43,8 +43,8 @@ FATAL Error downloading: Unable to verify checksum signature against PGP key
 Solution: Your locally cached copy of HashiCorp's PGP public key is stale.
 Starting with Terraform 1.14.9, HashiCorp began signing releases with a
 refreshed key block after the original key block expired. This was fixed in
-_tfswitch_[v1.17.0](https://github.com/warrensbox/terraform-switcher/releases/tag/v1.17.0)
-and [v1.17.1](https://github.com/warrensbox/terraform-switcher/releases/tag/v1.17.1),
+_tfswitch_ [v1.17.0](https://github.com/warrensbox/terraform-switcher/releases/tag/v1.17.0)
+/ [v1.17.1](https://github.com/warrensbox/terraform-switcher/releases/tag/v1.17.1),
 but upgrading alone is not enough — if _tfswitch_ had already cached the key
 before that point, the stale single-block file remains on disk and the same
 error persists. Delete (rename to preserve just in case) the cached file so

--- a/www/docs/Troubleshoot.md
+++ b/www/docs/Troubleshoot.md
@@ -47,3 +47,22 @@ export PATH=$PATH:$HOME/.bin #Export your .bin into your path
 
 See the custom directory option `-b`:  
 ![custom directory](static/tfswitch-v7.gif "Custom binary path")
+
+---
+
+Problem:
+
+When installing Terraform 1.14.9 or later using tfswitch v1.16.0 or earlier, or after upgrading to v1.17.0+ without clearing the locally cached HashiCorp PGP key:
+
+```sh
+ERROR Could not verify PGP signature using key №1 (out of 1): Signature Verification Error: Invalid signature caused by openpgp: key expired
+FATAL Error downloading: Unable to verify checksum signature against PGP key
+```
+
+Solution: Your locally cached copy of HashiCorp's PGP public key is stale. Starting with Terraform 1.14.9, HashiCorp began signing releases with a refreshed key block after the original key block expired. This was fixed in tfswitch v1.17.0 (#747), but upgrading alone is not enough — if tfswitch had already cached the key before that point, the stale single-block file remains on disk and the same error persists. Delete the cached file so tfswitch re-downloads the current key:
+
+```sh
+rm ~/.terraform.versions/terraform_72D7468F.asc
+tfswitch <version>
+```
+

--- a/www/docs/Troubleshoot.md
+++ b/www/docs/Troubleshoot.md
@@ -1,68 +1,56 @@
-<!-- markdownlint-disable MD041 -->
+# Troubleshooting
 
-Problem:
+## Permissions issues when installing tfswitch
 
-```sh
-install: can't change permissions of /usr/local/bin: Operation not permitted
-```
+* `install: can't change permissions of /usr/local/bin: Operation not permitted`
+* `"Unable to remove symlink. You must have SUDO privileges"`
+* `"Unable to create symlink. You must have SUDO privileges"`
+* `install: cannot create regular file '/usr/local/bin/tfswitch': Permission denied`
 
-```sh
-"Unable to remove symlink. You must have SUDO privileges"
-```
+Solution: You probably need to have privileges to install _tfswitch_ at `/usr/local/bin`
 
-```sh
-"Unable to create symlink. You must have SUDO privileges"
-```
+Try the following by installing `tfswtich` to your local bin directory instead:
 
 ```sh
-install: cannot create regular file '/usr/local/bin/tfswitch': Permission denied
-```
+mkdir -p "$HOME/.local/bin"
+curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | bash -s -- -b "$HOME/.local/bin"
+$HOME/.local/bin/tfswitch --version # test executable: should print the version of tfswitch
+export PATH="$PATH:$HOME/.local/bin" # you should consider adding this to .bash_profile in your $HOME directory.
 
-Solution: You probably need to have privileges to install _tfswitch_ at /usr/local/bin.
+# Install Terraform 0.11.7 to $HOME/.local/bin/
+tfswitch -b $HOME/.local/bin/terraform 0.11.7
 
-Try the following:
-
-```sh
-wget https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh  #Get the installer on to your machine:
-
-chmod 755 install.sh #Make installer executable
-
-./install.sh -b $HOME/.bin #Install tfswitch in a location you have permission:
-
-$HOME/.bin/tfswitch #test
-
-export PATH=$PATH:$HOME/.bin #Export your .bin into your path
-
-#You should probably add step 4 in your `.bash_profile` in your $HOME directory.
-
-#Next, try:
-`tfswitch -b $HOME/.bin/terraform 0.11.7`
-
-#or simply
-
-`tfswitch -b $HOME/.bin/terraform`
-
+# Invoke selection menu and install to $HOME/.local/bin/
+tfswitch -b $HOME/.local/bin/terraform
 
 ```
 
 See the custom directory option `-b`:  
 ![custom directory](static/tfswitch-v7.gif "Custom binary path")
 
----
 
-Problem:
+## PGP signature verification error when installing Terraform 1.14.9+
 
-When installing Terraform 1.14.9 or later using tfswitch v1.16.0 or earlier, or after upgrading to v1.17.0+ without clearing the locally cached HashiCorp PGP key:
+When installing Terraform 1.14.9 or later using _tfswitch_ v1.16.0 or earlier,
+or after upgrading to v1.17.0+ without clearing the locally cached HashiCorp
+PGP key:
 
 ```sh
 ERROR Could not verify PGP signature using key №1 (out of 1): Signature Verification Error: Invalid signature caused by openpgp: key expired
 FATAL Error downloading: Unable to verify checksum signature against PGP key
 ```
 
-Solution: Your locally cached copy of HashiCorp's PGP public key is stale. Starting with Terraform 1.14.9, HashiCorp began signing releases with a refreshed key block after the original key block expired. This was fixed in tfswitch v1.17.0 (#747), but upgrading alone is not enough — if tfswitch had already cached the key before that point, the stale single-block file remains on disk and the same error persists. Delete the cached file so tfswitch re-downloads the current key:
+Solution: Your locally cached copy of HashiCorp's PGP public key is stale.
+Starting with Terraform 1.14.9, HashiCorp began signing releases with a
+refreshed key block after the original key block expired. This was fixed in
+_tfswitch_[v1.17.0](https://github.com/warrensbox/terraform-switcher/releases/tag/v1.17.0)
+and [v1.17.1](https://github.com/warrensbox/terraform-switcher/releases/tag/v1.17.1),
+but upgrading alone is not enough — if _tfswitch_ had already cached the key
+before that point, the stale single-block file remains on disk and the same
+error persists. Delete (rename to preserve just in case) the cached file so
+_tfswitch_ re-downloads the current key:
 
 ```sh
-rm ~/.terraform.versions/terraform_72D7468F.asc
+mv ~/.terraform.versions/terraform_72D7468F.asc ~/.terraform.versions/terraform_72D7468F.asc.old
 tfswitch <version>
 ```
-

--- a/www/docs/Troubleshoot.md
+++ b/www/docs/Troubleshoot.md
@@ -2,10 +2,10 @@
 
 ## Permissions issues when installing tfswitch
 
-* `install: can't change permissions of /usr/local/bin: Operation not permitted`
-* `"Unable to remove symlink. You must have SUDO privileges"`
-* `"Unable to create symlink. You must have SUDO privileges"`
-* `install: cannot create regular file '/usr/local/bin/tfswitch': Permission denied`
+- `install: can't change permissions of /usr/local/bin: Operation not permitted`
+- `"Unable to remove symlink. You must have SUDO privileges"`
+- `"Unable to create symlink. You must have SUDO privileges"`
+- `install: cannot create regular file '/usr/local/bin/tfswitch': Permission denied`
 
 Solution: You probably need to have privileges to install _tfswitch_ at `/usr/local/bin`
 
@@ -27,7 +27,6 @@ tfswitch -b $HOME/.local/bin/terraform
 
 See the custom directory option `-b`:  
 ![custom directory](static/tfswitch-v7.gif "Custom binary path")
-
 
 ## PGP signature verification error when installing Terraform 1.14.9+
 

--- a/www/docs/Troubleshoot.md
+++ b/www/docs/Troubleshoot.md
@@ -9,7 +9,7 @@
 
 Solution: You probably need to have privileges to install _tfswitch_ at `/usr/local/bin`
 
-Try the following by installing `tfswtich` to your local bin directory instead:
+Try the following by installing `tfswitch` to your local bin directory instead:
 
 ```sh
 mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
Closes #780.

Adds a troubleshooting entry for the `key expired` PGP verification error that affects users installing Terraform 1.14.9 or later.

The fix in #747 (v1.17.0) resolves the root cause, but users who already had a stale `~/.terraform.versions/terraform_72D7468F.asc` cached before HashiCorp added the refreshed key block continue to see the identical error even after upgrading. The new entry documents when this happens, why upgrading alone is not enough, and the one-line fix.