### PR TITLE
fix: Handle correct resetup of product entity when product entity is configured in a config source (e.g. toml) and then overriden in CLI

### DIFF
--- a/lib/param_parsing/parameters.go
+++ b/lib/param_parsing/parameters.go
@@ -249,6 +249,10 @@ func populateParams(params Params) Params {
 	// Parse again to overwrite anything that might be defined on the command line AND in any config file (CLI always wins)
 	getopt.Parse()
 	args := getopt.Args()
+
+	// Re-setup product for final time to handle any changes to product in CLI (that override other config sources)
+	setupProductParam(&params)
+
 	if len(args) == 1 && isNotShortRun { // Disregard args if "short" run (version or help)
 		/* version provided on command line as arg */
 		logger = lib.InitLogger(params.LogLevel)

--- a/lib/param_parsing/parameters_test.go
+++ b/lib/param_parsing/parameters_test.go
@@ -295,9 +295,10 @@ terraform_version_constraint = ">= 0.13, < 0.14"
 	os.Unsetenv("TF_DEFAULT_VERSION")
 }
 
-func checkExpectedPrecedenceProduct(t *testing.T, baseDir string, expectedProduct lib.Product) {
+func checkExpectedPrecedenceProduct(t *testing.T, baseDir string, expectedProduct lib.Product, args ...string) {
 	getopt.CommandLine = getopt.New()
 	os.Args = []string{"cmd", fmt.Sprintf("--chdir=%s", baseDir)}
+	os.Args = append(os.Args, args...)
 	parameters := Params{}
 	parameters = initParams(parameters)
 	parameters.TomlDir = baseDir
@@ -342,6 +343,9 @@ product = "opentofu"
 	os.Setenv("TF_PRODUCT", "terraform")
 	t.Log("Testing with environment variable")
 	checkExpectedPrecedenceProduct(t, tempDir, terraformProduct)
+
+	// Pass via command line and verify override
+	checkExpectedPrecedenceProduct(t, tempDir, openTofuProduct, "--product", "opentofu")
 
 	os.Unsetenv("TF_VERSION")
 }


### PR DESCRIPTION


Issue #742