### PR TITLE
chore: replace deprecated Homebrew cask postflight hook as of GoReleaser v2.19

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,9 +91,9 @@ homebrew_casks:
     hooks:
       post:
         # macOS: remove the quarantine bit from the binary
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/tfswitch"]
+        install_steps: |
+          on_macos do
+            run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ .StagedPath }}/tfswitch"]
           end
 
 changelog:


### PR DESCRIPTION
Fixes #821

## What changes

The `homebrew_casks` hook in `.goreleaser.yml` moves from `hooks.post.install` to `hooks.post.install_steps`. The generated cask then uses the `postflight_steps` stanza instead of the deprecated `postflight` block. The step runs the same `xattr -dr com.apple.quarantine` command on the staged binary. `on_macos` replaces `if OS.mac?`, and `{{ .StagedPath }}` renders Homebrew's `{{staged_path}}` token.

## Why this is a draft

The `install_steps` option comes with goreleaser/goreleaser#6873, which the GoReleaser maintainer targets for v2.19. That version is not released yet. GoReleaser v2.18.1 rejects the new field:

```
yaml: unmarshal errors:
  line 94: field install_steps not found in type config.HomebrewCaskHook
```

Do not merge before GoReleaser v2.19 is out. The release workflow runs GoReleaser with `version: latest`, so no workflow change is needed after that. I will mark this ready for review when v2.19 ships.

## Verification

I built GoReleaser from goreleaser/goreleaser#6873 at commit 38c7541 and ran it against this branch:

- `goreleaser check` passes.
- `goreleaser release --snapshot` renders `dist/homebrew/Casks/tfswitch.rb` with this stanza:

```ruby
  postflight_steps do
    on_macos do
      run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{staged_path}}/tfswitch"]
    end
  end
```

This is the same stanza as the manual tap fix in warrensbox/homebrew-tap#11. That tap fix passed `brew audit` and a full `brew reinstall`, and the installed binary had no quarantine attribute afterwards.

---

ℹ️ Refs (by @yermulnik):
* https://github.com/Homebrew/brew/pull/23195
* https://brew.sh/2026/09/13/homebrew-7.0.0/#-install-steps
  > Status in 7.0.0: [official taps reject legacy hooks](https://github.com/Homebrew/brew/pull/23366); third-party taps receive warnings until 11 December 2027.